### PR TITLE
refactor larger components on /models

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import Leaderboard from "./pages/Leaderboard";
+import Models from "./pages/Models";
 import Pricing from "./pages/Pricing";
 import About from "./pages/About";
 import Privacy from "./pages/Privacy";
@@ -18,6 +19,7 @@ const App = () => (
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/leaderboard" element={<Leaderboard />} />
+          <Route path="/models" element={<Models />} />
           <Route path="/pricing" element={<Pricing />} />
           <Route path="/about" element={<About />} />
           <Route path="/privacy" element={<Privacy />} />

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -88,6 +88,12 @@ const Header = () => {
               </a>
               <a
                 className="transition-colors hover:text-foreground/80 text-foreground/60"
+                href="/models"
+              >
+                Models
+              </a>
+              <a
+                className="transition-colors hover:text-foreground/80 text-foreground/60"
                 href="/pricing"
               >
                 Pricing
@@ -172,6 +178,13 @@ const Header = () => {
                     className="block text-center py-4 px-4 rounded-md text-sm font-medium transition-colors hover:bg-muted hover:text-foreground text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   >
                     Leaderboard
+                  </a>
+                  <a
+                    href="/models"
+                    onClick={closeMobileMenu}
+                    className="block text-center py-4 px-4 rounded-md text-sm font-medium transition-colors hover:bg-muted hover:text-foreground text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    Models
                   </a>
                   <a
                     href="/pricing"

--- a/frontend/src/components/ModelExecutionDashboard.tsx
+++ b/frontend/src/components/ModelExecutionDashboard.tsx
@@ -419,10 +419,27 @@ const ModelExecutionDashboard = () => {
         <h2 className="text-2xl font-bold tracking-tight md:text-3xl">
           Model Execution Dashboard 🚀
         </h2>
-        <p className="text-muted-foreground max-w-2xl mx-auto">
-          Real-time view of AI model execution across all exposed servers. 
-          Track which models are running where, and when.
-        </p>
+        
+        {/* Haiku */}
+        <div className="max-w-md mx-auto p-4 bg-gradient-to-r from-blue-500/10 to-purple-500/10 border border-blue-500/20 rounded-lg">
+          <div className="text-sm font-mono text-muted-foreground italic leading-relaxed">
+            <div>No keys, no limits here</div>
+            <div>AI models run wild and free—</div>
+            <div>Internet's playground</div>
+          </div>
+        </div>
+        
+        {/* Body copy */}
+        <div className="text-muted-foreground max-w-3xl mx-auto space-y-2">
+          <p>
+            Welcome to the wild west of AI, where LLM servers roam free without authentication, rate limits, or adult supervision. 
+            These beautifully exposed endpoints are running everything from creative writing assistants to code generators—all waiting for your prompts.
+          </p>
+          <p className="text-sm">
+            What makes them special? Zero barriers, infinite possibilities, and the kind of open access that would make security teams weep. 
+            Perfect for experimentation, research, or just seeing what happens when AI meets the honor system.
+          </p>
+        </div>
       </div>
 
       {/* Summary Stats */}

--- a/frontend/src/components/ModelExecutionDashboard.tsx
+++ b/frontend/src/components/ModelExecutionDashboard.tsx
@@ -1,0 +1,690 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { 
+  Search, 
+  ChevronDown, 
+  ChevronUp, 
+  Play, 
+  Square, 
+  Server, 
+  Clock, 
+  Activity,
+  Filter,
+  SortAsc,
+  SortDesc,
+  RefreshCw,
+  Database,
+  MapPin,
+  Zap,
+  HardDrive
+} from "lucide-react";
+import { formatDistanceToNowStrict } from "date-fns";
+import AnimatedCounter from './AnimatedCounter';
+
+interface ServerModel {
+  name: string;
+  model: string;
+  size: number;
+}
+
+interface ServerData {
+  ip: string;
+  port: number;
+  version: string;
+  city: string;
+  country: string;
+  country_name: string;
+  region: string;
+  latitude: string;
+  longitude: string;
+  local: ServerModel[];
+  running: ServerModel[];
+  first_seen_online: string;
+  last_observed: string;
+  age: string;
+  status: string;
+}
+
+interface ModelExecution {
+  modelName: string;
+  totalServers: number;
+  runningServers: number;
+  totalSize: number;
+  averageSize: number;
+  servers: {
+    server: ServerData;
+    isRunning: boolean;
+    isLocal: boolean;
+    modelSize: number;
+    lastSeen: string;
+  }[];
+  lastActivity: string;
+  executionFrequency: number;
+}
+
+type SortOption = 'name' | 'servers' | 'running' | 'frequency' | 'size';
+type SortDirection = 'asc' | 'desc';
+type StatusFilter = 'all' | 'running' | 'stopped' | 'available';
+
+const ModelExecutionDashboard = () => {
+  const [serverData, setServerData] = useState<ServerData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [serverFilter, setServerFilter] = useState('all');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [sortBy, setSortBy] = useState<SortOption>('servers');
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+  const [expandedModels, setExpandedModels] = useState<Set<string>>(new Set());
+  const [refreshing, setRefreshing] = useState(false);
+
+  const fetchServerData = async (isRefresh = false) => {
+    try {
+      if (isRefresh) {
+        setRefreshing(true);
+      } else {
+        setLoading(true);
+      }
+      setError(null);
+      
+      const response = await fetch('/data/live_servers.json');
+      if (!response.ok) {
+        throw new Error(`Failed to fetch server data: ${response.status}`);
+      }
+      
+      const serversObject = await response.json();
+      const serverEntries = Object.values(serversObject) as ServerData[];
+      
+      setServerData(serverEntries);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load model execution data');
+      console.error('Error fetching server data:', err);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchServerData();
+    
+    // Set up auto-refresh every 30 seconds
+    const interval = setInterval(() => {
+      fetchServerData(true);
+    }, 30000);
+    
+    return () => clearInterval(interval);
+  }, []);
+
+  const modelExecutions = useMemo(() => {
+    const modelMap = new Map<string, ModelExecution>();
+    
+    serverData.forEach(server => {
+      // Process local models
+      server.local.forEach(model => {
+        const key = model.name;
+        if (!modelMap.has(key)) {
+          modelMap.set(key, {
+            modelName: model.name,
+            totalServers: 0,
+            runningServers: 0,
+            totalSize: 0,
+            averageSize: 0,
+            servers: [],
+            lastActivity: server.last_observed,
+            executionFrequency: 0
+          });
+        }
+        
+        const execution = modelMap.get(key)!;
+        const isRunning = server.running.some(runningModel => runningModel.name === model.name);
+        
+        execution.servers.push({
+          server,
+          isRunning,
+          isLocal: true,
+          modelSize: model.size,
+          lastSeen: server.last_observed
+        });
+        
+        execution.totalServers++;
+        if (isRunning) execution.runningServers++;
+        execution.totalSize += model.size;
+        
+        // Update last activity if this server was seen more recently
+        if (new Date(server.last_observed) > new Date(execution.lastActivity)) {
+          execution.lastActivity = server.last_observed;
+        }
+      });
+      
+      // Process running models that might not be in local
+      server.running.forEach(model => {
+        const key = model.name;
+        if (!modelMap.has(key)) {
+          modelMap.set(key, {
+            modelName: model.name,
+            totalServers: 0,
+            runningServers: 0,
+            totalSize: 0,
+            averageSize: 0,
+            servers: [],
+            lastActivity: server.last_observed,
+            executionFrequency: 0
+          });
+        }
+        
+        const execution = modelMap.get(key)!;
+        const existingServer = execution.servers.find(s => s.server.ip === server.ip && s.server.port === server.port);
+        
+        if (!existingServer) {
+          execution.servers.push({
+            server,
+            isRunning: true,
+            isLocal: false,
+            modelSize: model.size,
+            lastSeen: server.last_observed
+          });
+          
+          execution.totalServers++;
+          execution.runningServers++;
+          execution.totalSize += model.size;
+        }
+      });
+    });
+    
+    // Calculate averages and execution frequency
+    modelMap.forEach(execution => {
+      execution.averageSize = execution.totalSize / execution.totalServers;
+      execution.executionFrequency = execution.runningServers / execution.totalServers;
+    });
+    
+    return Array.from(modelMap.values());
+  }, [serverData]);
+
+  const filteredAndSortedModels = useMemo(() => {
+    let filtered = modelExecutions.filter(model => {
+      // Search filter
+      if (searchTerm && !model.modelName.toLowerCase().includes(searchTerm.toLowerCase())) {
+        return false;
+      }
+      
+      // Server filter
+      if (serverFilter !== 'all') {
+        const hasServer = model.servers.some(s => 
+          `${s.server.ip}:${s.server.port}` === serverFilter ||
+          s.server.city.toLowerCase().includes(serverFilter.toLowerCase()) ||
+          s.server.country_name.toLowerCase().includes(serverFilter.toLowerCase())
+        );
+        if (!hasServer) return false;
+      }
+      
+      // Status filter
+      switch (statusFilter) {
+        case 'running':
+          return model.runningServers > 0;
+        case 'stopped':
+          return model.runningServers === 0 && model.totalServers > 0;
+        case 'available':
+          return model.totalServers > 0;
+        default:
+          return true;
+      }
+    });
+    
+    // Sort
+    filtered.sort((a, b) => {
+      let aValue: number | string;
+      let bValue: number | string;
+      
+      switch (sortBy) {
+        case 'name':
+          aValue = a.modelName.toLowerCase();
+          bValue = b.modelName.toLowerCase();
+          break;
+        case 'servers':
+          aValue = a.totalServers;
+          bValue = b.totalServers;
+          break;
+        case 'running':
+          aValue = a.runningServers;
+          bValue = b.runningServers;
+          break;
+        case 'frequency':
+          aValue = a.executionFrequency;
+          bValue = b.executionFrequency;
+          break;
+        case 'size':
+          aValue = a.averageSize;
+          bValue = b.averageSize;
+          break;
+        default:
+          aValue = a.totalServers;
+          bValue = b.totalServers;
+      }
+      
+      if (typeof aValue === 'string' && typeof bValue === 'string') {
+        return sortDirection === 'asc' ? aValue.localeCompare(bValue) : bValue.localeCompare(aValue);
+      }
+      
+      return sortDirection === 'asc' ? (aValue as number) - (bValue as number) : (bValue as number) - (aValue as number);
+    });
+    
+    return filtered;
+  }, [modelExecutions, searchTerm, serverFilter, statusFilter, sortBy, sortDirection]);
+
+  const formatSize = (bytes: number) => {
+    const gb = bytes / (1024 * 1024 * 1024);
+    if (gb >= 1) {
+      return `${gb.toFixed(1)}GB`;
+    }
+    const mb = bytes / (1024 * 1024);
+    return `${mb.toFixed(0)}MB`;
+  };
+
+  const formatTimestamp = (dateString: string) => {
+    try {
+      const date = new Date(dateString);
+      return formatDistanceToNowStrict(date, { addSuffix: true });
+    } catch {
+      return 'Unknown';
+    }
+  };
+
+  const getCountryFlag = (countryCode: string) => {
+    const flags: { [key: string]: string } = {
+      'CN': '🇨🇳', 'JP': '🇯🇵', 'GB': '🇬🇧', 'RU': '🇷🇺', 'US': '🇺🇸',
+      'DE': '🇩🇪', 'FR': '🇫🇷', 'IT': '🇮🇹', 'ES': '🇪🇸', 'CA': '🇨🇦',
+      'AU': '🇦🇺', 'BR': '🇧🇷', 'IN': '🇮🇳', 'KR': '🇰🇷'
+    };
+    return flags[countryCode] || '🌍';
+  };
+
+  const toggleModelExpansion = (modelName: string) => {
+    const newExpanded = new Set(expandedModels);
+    if (newExpanded.has(modelName)) {
+      newExpanded.delete(modelName);
+    } else {
+      newExpanded.add(modelName);
+    }
+    setExpandedModels(newExpanded);
+  };
+
+  const handleRefresh = () => {
+    fetchServerData(true);
+  };
+
+  const uniqueServers = useMemo(() => {
+    const servers = new Set<string>();
+    serverData.forEach(server => {
+      servers.add(`${server.ip}:${server.port}`);
+      servers.add(server.city);
+      servers.add(server.country_name);
+    });
+    return Array.from(servers).sort();
+  }, [serverData]);
+
+  if (loading) {
+    return (
+      <section className="container py-16">
+        <div className="text-center space-y-4 mb-12">
+          <h2 className="text-2xl font-bold tracking-tight md:text-3xl">
+            Model Execution Dashboard
+          </h2>
+          <p className="text-muted-foreground max-w-2xl mx-auto">
+            Loading model execution data across all servers...
+          </p>
+        </div>
+        
+        <div className="space-y-4 max-w-6xl mx-auto">
+          {[1, 2, 3].map((index) => (
+            <div
+              key={index}
+              className="relative p-6 rounded-lg border backdrop-blur-sm bg-muted/20 border-muted animate-pulse"
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-4">
+                  <div className="h-6 bg-muted rounded w-32"></div>
+                  <div className="h-4 bg-muted rounded w-20"></div>
+                </div>
+                <div className="text-right space-y-2">
+                  <div className="h-4 bg-muted rounded w-24"></div>
+                  <div className="h-4 bg-muted rounded w-20"></div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section className="container py-16">
+        <div className="text-center">
+          <h2 className="text-2xl font-bold tracking-tight md:text-3xl mb-4">
+            Model Execution Dashboard
+          </h2>
+          <p className="text-destructive mb-2">Failed to load model execution data</p>
+          <p className="text-xs text-muted-foreground">{error}</p>
+          <Button onClick={() => fetchServerData()} className="mt-4">
+            <RefreshCw className="h-4 w-4 mr-2" />
+            Retry
+          </Button>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="container py-16">
+      {/* Header */}
+      <div className="text-center space-y-4 mb-12">
+        <h2 className="text-2xl font-bold tracking-tight md:text-3xl">
+          Model Execution Dashboard 🚀
+        </h2>
+        <p className="text-muted-foreground max-w-2xl mx-auto">
+          Real-time view of AI model execution across all exposed servers. 
+          Track which models are running where, and when.
+        </p>
+      </div>
+
+      {/* Summary Stats */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8 max-w-4xl mx-auto">
+        <Card className="text-center">
+          <CardContent className="pt-6">
+            <div className="text-2xl font-bold text-primary">
+              <AnimatedCounter target={modelExecutions.length} duration={1500} />
+            </div>
+            <div className="text-sm text-muted-foreground">Unique Models</div>
+          </CardContent>
+        </Card>
+        
+        <Card className="text-center">
+          <CardContent className="pt-6">
+            <div className="text-2xl font-bold text-green-500">
+              <AnimatedCounter 
+                target={modelExecutions.reduce((sum, model) => sum + model.runningServers, 0)} 
+                duration={1500} 
+              />
+            </div>
+            <div className="text-sm text-muted-foreground">Active Executions</div>
+          </CardContent>
+        </Card>
+        
+        <Card className="text-center">
+          <CardContent className="pt-6">
+            <div className="text-2xl font-bold text-blue-500">
+              <AnimatedCounter target={serverData.length} duration={1500} />
+            </div>
+            <div className="text-sm text-muted-foreground">Total Servers</div>
+          </CardContent>
+        </Card>
+        
+        <Card className="text-center">
+          <CardContent className="pt-6">
+            <div className="text-2xl font-bold text-orange-500">
+              <AnimatedCounter 
+                target={Math.round(modelExecutions.reduce((sum, model) => sum + model.totalSize, 0) / (1024 * 1024 * 1024))} 
+                duration={1500} 
+              />
+              <span className="text-sm font-normal">GB</span>
+            </div>
+            <div className="text-sm text-muted-foreground">Total Model Size</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Filters and Controls */}
+      <div className="max-w-6xl mx-auto mb-8">
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-lg flex items-center gap-2">
+                <Filter className="h-5 w-5" />
+                Filters & Controls
+              </CardTitle>
+              <Button
+                onClick={handleRefresh}
+                disabled={refreshing}
+                size="sm"
+                variant="outline"
+                className="gap-2"
+              >
+                <RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />
+                {refreshing ? 'Refreshing...' : 'Refresh'}
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+              {/* Search */}
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <Input
+                  placeholder="Search models..."
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                  className="pl-10"
+                />
+              </div>
+
+              {/* Server Filter */}
+              <Select value={serverFilter} onValueChange={setServerFilter}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Filter by server" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All Servers</SelectItem>
+                  {uniqueServers.slice(0, 20).map(server => (
+                    <SelectItem key={server} value={server}>{server}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              {/* Status Filter */}
+              <Select value={statusFilter} onValueChange={(value: StatusFilter) => setStatusFilter(value)}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Filter by status" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All Status</SelectItem>
+                  <SelectItem value="running">Currently Running</SelectItem>
+                  <SelectItem value="stopped">Available but Stopped</SelectItem>
+                  <SelectItem value="available">Available on Servers</SelectItem>
+                </SelectContent>
+              </Select>
+
+              {/* Sort By */}
+              <Select value={sortBy} onValueChange={(value: SortOption) => setSortBy(value)}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Sort by" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="name">Model Name</SelectItem>
+                  <SelectItem value="servers">Server Count</SelectItem>
+                  <SelectItem value="running">Running Count</SelectItem>
+                  <SelectItem value="frequency">Execution Frequency</SelectItem>
+                  <SelectItem value="size">Average Size</SelectItem>
+                </SelectContent>
+              </Select>
+
+              {/* Sort Direction */}
+              <Button
+                variant="outline"
+                onClick={() => setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc')}
+                className="gap-2"
+              >
+                {sortDirection === 'asc' ? <SortAsc className="h-4 w-4" /> : <SortDesc className="h-4 w-4" />}
+                {sortDirection === 'asc' ? 'Ascending' : 'Descending'}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Model List */}
+      <div className="space-y-4 max-w-6xl mx-auto">
+        {filteredAndSortedModels.length === 0 ? (
+          <Card>
+            <CardContent className="text-center py-12">
+              <Database className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
+              <h3 className="text-lg font-semibold mb-2">No Models Found</h3>
+              <p className="text-muted-foreground">
+                Try adjusting your filters or search terms to find models.
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          filteredAndSortedModels.map((model) => (
+            <Card key={model.modelName} className="overflow-hidden">
+              <Collapsible
+                open={expandedModels.has(model.modelName)}
+                onOpenChange={() => toggleModelExpansion(model.modelName)}
+              >
+                <CollapsibleTrigger asChild>
+                  <CardHeader className="cursor-pointer hover:bg-muted/50 transition-colors">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-4">
+                        <div className="flex items-center gap-2">
+                          {expandedModels.has(model.modelName) ? 
+                            <ChevronUp className="h-5 w-5" /> : 
+                            <ChevronDown className="h-5 w-5" />
+                          }
+                          <CardTitle className="text-xl">{model.modelName}</CardTitle>
+                        </div>
+                        
+                        <div className="flex items-center gap-2">
+                          {model.runningServers > 0 ? (
+                            <Badge variant="default" className="bg-green-500 gap-1">
+                              <Play className="h-3 w-3" />
+                              {model.runningServers} Running
+                            </Badge>
+                          ) : (
+                            <Badge variant="secondary" className="gap-1">
+                              <Square className="h-3 w-3" />
+                              Stopped
+                            </Badge>
+                          )}
+                          
+                          <Badge variant="outline" className="gap-1">
+                            <Server className="h-3 w-3" />
+                            {model.totalServers} Servers
+                          </Badge>
+                          
+                          <Badge variant="outline" className="gap-1">
+                            <HardDrive className="h-3 w-3" />
+                            {formatSize(model.averageSize)} avg
+                          </Badge>
+                        </div>
+                      </div>
+
+                      <div className="text-right">
+                        <div className="text-sm text-muted-foreground flex items-center gap-1">
+                          <Clock className="h-3 w-3" />
+                          Last seen {formatTimestamp(model.lastActivity)}
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {Math.round(model.executionFrequency * 100)}% execution rate
+                        </div>
+                      </div>
+                    </div>
+                  </CardHeader>
+                </CollapsibleTrigger>
+
+                <CollapsibleContent>
+                  <CardContent className="pt-0">
+                    <div className="space-y-4">
+                      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 p-4 bg-muted/20 rounded-lg">
+                        <div className="text-center">
+                          <div className="text-2xl font-bold text-primary">{model.totalServers}</div>
+                          <div className="text-sm text-muted-foreground">Total Servers</div>
+                        </div>
+                        <div className="text-center">
+                          <div className="text-2xl font-bold text-green-500">{model.runningServers}</div>
+                          <div className="text-sm text-muted-foreground">Currently Running</div>
+                        </div>
+                        <div className="text-center">
+                          <div className="text-2xl font-bold text-blue-500">{formatSize(model.totalSize)}</div>
+                          <div className="text-sm text-muted-foreground">Total Size</div>
+                        </div>
+                      </div>
+
+                      <div>
+                        <h4 className="font-semibold mb-3 flex items-center gap-2">
+                          <Server className="h-4 w-4" />
+                          Server Locations ({model.servers.length})
+                        </h4>
+                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                          {model.servers.map((serverInfo, index) => (
+                            <Card key={`${serverInfo.server.ip}-${serverInfo.server.port}-${index}`} className="p-4">
+                              <div className="space-y-2">
+                                <div className="flex items-center justify-between">
+                                  <div className="font-mono text-sm">
+                                    {serverInfo.server.ip}:{serverInfo.server.port}
+                                  </div>
+                                  <div className="flex items-center gap-2">
+                                    {serverInfo.isRunning ? (
+                                      <Badge variant="default" className="bg-green-500 gap-1">
+                                        <Play className="h-3 w-3" />
+                                        Running
+                                      </Badge>
+                                    ) : (
+                                      <Badge variant="secondary" className="gap-1">
+                                        <Square className="h-3 w-3" />
+                                        Available
+                                      </Badge>
+                                    )}
+                                  </div>
+                                </div>
+                                
+                                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                  <span>{getCountryFlag(serverInfo.server.country)}</span>
+                                  <span>{serverInfo.server.city}, {serverInfo.server.country_name}</span>
+                                </div>
+                                
+                                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                                  <span className="flex items-center gap-1">
+                                    <HardDrive className="h-3 w-3" />
+                                    {formatSize(serverInfo.modelSize)}
+                                  </span>
+                                  <span className="flex items-center gap-1">
+                                    <Clock className="h-3 w-3" />
+                                    {formatTimestamp(serverInfo.lastSeen)}
+                                  </span>
+                                </div>
+                                
+                                <div className="text-xs text-muted-foreground">
+                                  Version: {serverInfo.server.version} | 
+                                  Status: {serverInfo.server.status}
+                                </div>
+                              </div>
+                            </Card>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                  </CardContent>
+                </CollapsibleContent>
+              </Collapsible>
+            </Card>
+          ))
+        )}
+      </div>
+
+      {/* Footer Info */}
+      <div className="text-center mt-12">
+        <p className="text-sm text-muted-foreground">
+          Data refreshes automatically every 30 seconds. Last updated: {formatTimestamp(new Date().toISOString())}
+        </p>
+      </div>
+    </section>
+  );
+};
+
+export default ModelExecutionDashboard;

--- a/frontend/src/components/ModelExecutionDashboard.tsx
+++ b/frontend/src/components/ModelExecutionDashboard.tsx
@@ -23,6 +23,15 @@ import {
   Zap,
   HardDrive
 } from "lucide-react";
+import { 
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+  PaginationEllipsis,
+} from "@/components/ui/pagination";
 import { formatDistanceToNowStrict } from "date-fns";
 import AnimatedCounter from './AnimatedCounter';
 
@@ -82,6 +91,8 @@ const ModelExecutionDashboard = () => {
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const [expandedModels, setExpandedModels] = useState<Set<string>>(new Set());
   const [refreshing, setRefreshing] = useState(false);
+  const [currentPage, setCurrentPage] = useState(1);
+  const modelsPerPage = 10;
 
   const fetchServerData = async (isRefresh = false) => {
     try {
@@ -206,6 +217,11 @@ const ModelExecutionDashboard = () => {
     return Array.from(modelMap.values());
   }, [serverData]);
 
+  // Reset current page when filters or sorting change
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchTerm, serverFilter, statusFilter, sortBy, sortDirection]);
+
   const filteredAndSortedModels = useMemo(() => {
     let filtered = modelExecutions.filter(model => {
       // Search filter
@@ -277,6 +293,12 @@ const ModelExecutionDashboard = () => {
     return filtered;
   }, [modelExecutions, searchTerm, serverFilter, statusFilter, sortBy, sortDirection]);
 
+  // Calculate pagination
+  const totalPages = Math.ceil(filteredAndSortedModels.length / modelsPerPage);
+  const indexOfLastModel = currentPage * modelsPerPage;
+  const indexOfFirstModel = indexOfLastModel - modelsPerPage;
+  const currentModels = filteredAndSortedModels.slice(indexOfFirstModel, indexOfLastModel);
+
   const formatSize = (bytes: number) => {
     const gb = bytes / (1024 * 1024 * 1024);
     if (gb >= 1) {
@@ -316,6 +338,15 @@ const ModelExecutionDashboard = () => {
 
   const handleRefresh = () => {
     fetchServerData(true);
+  };
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+    // Scroll to top of the models section when page changes
+    const modelsSection = document.getElementById('models-section');
+    if (modelsSection) {
+      modelsSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
   };
 
   const uniqueServers = useMemo(() => {
@@ -529,7 +560,19 @@ const ModelExecutionDashboard = () => {
       </div>
 
       {/* Model List */}
-      <div className="space-y-4 max-w-6xl mx-auto">
+      <div id="models-section" className="space-y-4 max-w-6xl mx-auto">
+        {/* Results Summary */}
+        {filteredAndSortedModels.length > 0 && (
+          <div className="flex items-center justify-between mb-6">
+            <div className="text-sm text-muted-foreground">
+              Showing {indexOfFirstModel + 1}-{Math.min(indexOfLastModel, filteredAndSortedModels.length)} of {filteredAndSortedModels.length} models
+            </div>
+            <div className="text-sm text-muted-foreground">
+              Page {currentPage} of {totalPages}
+            </div>
+          </div>
+        )}
+
         {filteredAndSortedModels.length === 0 ? (
           <Card>
             <CardContent className="text-center py-12">
@@ -541,7 +584,7 @@ const ModelExecutionDashboard = () => {
             </CardContent>
           </Card>
         ) : (
-          filteredAndSortedModels.map((model) => (
+          currentModels.map((model) => (
             <Card key={model.modelName} className="overflow-hidden">
               <Collapsible
                 open={expandedModels.has(model.modelName)}
@@ -676,6 +719,87 @@ const ModelExecutionDashboard = () => {
           ))
         )}
       </div>
+
+      {/* Pagination Controls */}
+      {totalPages > 1 && (
+        <div className="flex justify-center mt-8">
+          <Pagination>
+            <PaginationContent>
+              <PaginationItem>
+                <PaginationPrevious 
+                  onClick={() => handlePageChange(Math.max(1, currentPage - 1))}
+                  className={currentPage === 1 ? 'pointer-events-none opacity-50' : 'cursor-pointer'}
+                />
+              </PaginationItem>
+              
+              {/* First page */}
+              {currentPage > 3 && (
+                <>
+                  <PaginationItem>
+                    <PaginationLink 
+                      onClick={() => handlePageChange(1)}
+                      isActive={currentPage === 1}
+                      className="cursor-pointer"
+                    >
+                      1
+                    </PaginationLink>
+                  </PaginationItem>
+                  {currentPage > 4 && (
+                    <PaginationItem>
+                      <PaginationEllipsis />
+                    </PaginationItem>
+                  )}
+                </>
+              )}
+              
+              {/* Page numbers around current page */}
+              {Array.from({ length: totalPages }, (_, i) => i + 1)
+                .filter(page => {
+                  return page >= Math.max(1, currentPage - 2) && 
+                         page <= Math.min(totalPages, currentPage + 2);
+                })
+                .map(page => (
+                  <PaginationItem key={page}>
+                    <PaginationLink 
+                      onClick={() => handlePageChange(page)}
+                      isActive={currentPage === page}
+                      className="cursor-pointer"
+                    >
+                      {page}
+                    </PaginationLink>
+                  </PaginationItem>
+                ))}
+              
+              {/* Last page */}
+              {currentPage < totalPages - 2 && (
+                <>
+                  {currentPage < totalPages - 3 && (
+                    <PaginationItem>
+                      <PaginationEllipsis />
+                    </PaginationItem>
+                  )}
+                  <PaginationItem>
+                    <PaginationLink 
+                      onClick={() => handlePageChange(totalPages)}
+                      isActive={currentPage === totalPages}
+                      className="cursor-pointer"
+                    >
+                      {totalPages}
+                    </PaginationLink>
+                  </PaginationItem>
+                </>
+              )}
+              
+              <PaginationItem>
+                <PaginationNext 
+                  onClick={() => handlePageChange(Math.min(totalPages, currentPage + 1))}
+                  className={currentPage === totalPages ? 'pointer-events-none opacity-50' : 'cursor-pointer'}
+                />
+              </PaginationItem>
+            </PaginationContent>
+          </Pagination>
+        </div>
+      )}
 
       {/* Footer Info */}
       <div className="text-center mt-12">

--- a/frontend/src/components/ModelExecutionDashboard.tsx
+++ b/frontend/src/components/ModelExecutionDashboard.tsx
@@ -1,84 +1,11 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
-import { 
-  Search, 
-  ChevronDown, 
-  ChevronUp, 
-  Play, 
-  Square, 
-  Server, 
-  Clock, 
-  Activity,
-  Filter,
-  SortAsc,
-  SortDesc,
-  RefreshCw,
-  Database,
-  MapPin,
-  Zap,
-  HardDrive
-} from "lucide-react";
-import { 
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-  PaginationEllipsis,
-} from "@/components/ui/pagination";
+import { ServerData, ModelExecution, SortOption, SortDirection, StatusFilter } from '@/types/ModelExecution';
+import BasePage from './dashboard/BasePage';
+import SummaryStats from './dashboard/SummaryStats';
+import FilterControls from './dashboard/FilterControls';
+import ModelList from './dashboard/ModelList';
+import PaginationControls from './dashboard/PaginationControls';
 import { formatDistanceToNowStrict } from "date-fns";
-import AnimatedCounter from './AnimatedCounter';
-
-interface ServerModel {
-  name: string;
-  model: string;
-  size: number;
-}
-
-interface ServerData {
-  ip: string;
-  port: number;
-  version: string;
-  city: string;
-  country: string;
-  country_name: string;
-  region: string;
-  latitude: string;
-  longitude: string;
-  local: ServerModel[];
-  running: ServerModel[];
-  first_seen_online: string;
-  last_observed: string;
-  age: string;
-  status: string;
-}
-
-interface ModelExecution {
-  modelName: string;
-  totalServers: number;
-  runningServers: number;
-  totalSize: number;
-  averageSize: number;
-  servers: {
-    server: ServerData;
-    isRunning: boolean;
-    isLocal: boolean;
-    modelSize: number;
-    lastSeen: string;
-  }[];
-  lastActivity: string;
-  executionFrequency: number;
-}
-
-type SortOption = 'name' | 'servers' | 'running' | 'frequency' | 'size';
-type SortDirection = 'asc' | 'desc';
-type StatusFilter = 'all' | 'running' | 'stopped' | 'available';
 
 const ModelExecutionDashboard = () => {
   const [serverData, setServerData] = useState<ServerData[]>([]);
@@ -210,8 +137,8 @@ const ModelExecutionDashboard = () => {
     
     // Calculate averages and execution frequency
     modelMap.forEach(execution => {
-      execution.averageSize = execution.totalSize / execution.totalServers;
-      execution.executionFrequency = execution.runningServers / execution.totalServers;
+      execution.averageSize = execution.totalServers > 0 ? execution.totalSize / execution.totalServers : 0;
+      execution.executionFrequency = execution.totalServers > 0 ? execution.runningServers / execution.totalServers : 0;
     });
     
     return Array.from(modelMap.values());
@@ -223,7 +150,7 @@ const ModelExecutionDashboard = () => {
   }, [searchTerm, serverFilter, statusFilter, sortBy, sortDirection]);
 
   const filteredAndSortedModels = useMemo(() => {
-    let filtered = modelExecutions.filter(model => {
+    const filtered = modelExecutions.filter(model => {
       // Search filter
       if (searchTerm && !model.modelName.toLowerCase().includes(searchTerm.toLowerCase())) {
         return false;
@@ -299,33 +226,6 @@ const ModelExecutionDashboard = () => {
   const indexOfFirstModel = indexOfLastModel - modelsPerPage;
   const currentModels = filteredAndSortedModels.slice(indexOfFirstModel, indexOfLastModel);
 
-  const formatSize = (bytes: number) => {
-    const gb = bytes / (1024 * 1024 * 1024);
-    if (gb >= 1) {
-      return `${gb.toFixed(1)}GB`;
-    }
-    const mb = bytes / (1024 * 1024);
-    return `${mb.toFixed(0)}MB`;
-  };
-
-  const formatTimestamp = (dateString: string) => {
-    try {
-      const date = new Date(dateString);
-      return formatDistanceToNowStrict(date, { addSuffix: true });
-    } catch {
-      return 'Unknown';
-    }
-  };
-
-  const getCountryFlag = (countryCode: string) => {
-    const flags: { [key: string]: string } = {
-      'CN': '🇨🇳', 'JP': '🇯🇵', 'GB': '🇬🇧', 'RU': '🇷🇺', 'US': '🇺🇸',
-      'DE': '🇩🇪', 'FR': '🇫🇷', 'IT': '🇮🇹', 'ES': '🇪🇸', 'CA': '🇨🇦',
-      'AU': '🇦🇺', 'BR': '🇧🇷', 'IN': '🇮🇳', 'KR': '🇰🇷'
-    };
-    return flags[countryCode] || '🌍';
-  };
-
   const toggleModelExpansion = (modelName: string) => {
     const newExpanded = new Set(expandedModels);
     if (newExpanded.has(modelName)) {
@@ -359,472 +259,45 @@ const ModelExecutionDashboard = () => {
     return Array.from(servers).sort();
   }, [serverData]);
 
-  if (loading) {
-    return (
-      <section className="container py-16">
-        <div className="text-center space-y-4 mb-12">
-          <h2 className="text-2xl font-bold tracking-tight md:text-3xl">
-            Model Execution Dashboard
-          </h2>
-          <p className="text-muted-foreground max-w-2xl mx-auto">
-            Loading model execution data across all servers...
-          </p>
-        </div>
-        
-        <div className="space-y-4 max-w-6xl mx-auto">
-          {[1, 2, 3].map((index) => (
-            <div
-              key={index}
-              className="relative p-6 rounded-lg border backdrop-blur-sm bg-muted/20 border-muted animate-pulse"
-            >
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-4">
-                  <div className="h-6 bg-muted rounded w-32"></div>
-                  <div className="h-4 bg-muted rounded w-20"></div>
-                </div>
-                <div className="text-right space-y-2">
-                  <div className="h-4 bg-muted rounded w-24"></div>
-                  <div className="h-4 bg-muted rounded w-20"></div>
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-      </section>
-    );
-  }
-
-  if (error) {
-    return (
-      <section className="container py-16">
-        <div className="text-center">
-          <h2 className="text-2xl font-bold tracking-tight md:text-3xl mb-4">
-            Model Execution Dashboard
-          </h2>
-          <p className="text-destructive mb-2">Failed to load model execution data</p>
-          <p className="text-xs text-muted-foreground">{error}</p>
-          <Button onClick={() => fetchServerData()} className="mt-4">
-            <RefreshCw className="h-4 w-4 mr-2" />
-            Retry
-          </Button>
-        </div>
-      </section>
-    );
-  }
-
   return (
-    <section className="container py-16">
-      {/* Header */}
-      <div className="text-center space-y-4 mb-12">
-        <h2 className="text-2xl font-bold tracking-tight md:text-3xl">
-          Model Execution Dashboard 🚀
-        </h2>
-        
-        {/* Haiku */}
-        <div className="max-w-md mx-auto p-4 bg-gradient-to-r from-blue-500/10 to-purple-500/10 border border-blue-500/20 rounded-lg">
-          <div className="text-sm font-mono text-muted-foreground italic leading-relaxed">
-            <div>No keys, no limits here</div>
-            <div>AI models run wild and free—</div>
-            <div>Internet's playground</div>
-          </div>
-        </div>
-        
-        {/* Body copy */}
-        <div className="text-muted-foreground max-w-3xl mx-auto space-y-2">
-          <p>
-            Welcome to the wild west of AI, where LLM servers roam free without authentication, rate limits, or adult supervision. 
-            These beautifully exposed endpoints are running everything from creative writing assistants to code generators—all waiting for your prompts.
-          </p>
-          <p className="text-sm">
-            What makes them special? Zero barriers, infinite possibilities, and the kind of open access that would make security teams weep. 
-            Perfect for experimentation, research, or just seeing what happens when AI meets the honor system.
-          </p>
-        </div>
-      </div>
-
-      {/* Summary Stats */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8 max-w-4xl mx-auto">
-        <Card className="text-center">
-          <CardContent className="pt-6">
-            <div className="text-2xl font-bold text-primary">
-              <AnimatedCounter target={modelExecutions.length} duration={1500} />
-            </div>
-            <div className="text-sm text-muted-foreground">Unique Models</div>
-          </CardContent>
-        </Card>
-        
-        <Card className="text-center">
-          <CardContent className="pt-6">
-            <div className="text-2xl font-bold text-green-500">
-              <AnimatedCounter 
-                target={modelExecutions.reduce((sum, model) => sum + model.runningServers, 0)} 
-                duration={1500} 
-              />
-            </div>
-            <div className="text-sm text-muted-foreground">Active Executions</div>
-          </CardContent>
-        </Card>
-        
-        <Card className="text-center">
-          <CardContent className="pt-6">
-            <div className="text-2xl font-bold text-blue-500">
-              <AnimatedCounter target={serverData.length} duration={1500} />
-            </div>
-            <div className="text-sm text-muted-foreground">Total Servers</div>
-          </CardContent>
-        </Card>
-        
-        <Card className="text-center">
-          <CardContent className="pt-6">
-            <div className="text-2xl font-bold text-orange-500">
-              <AnimatedCounter 
-                target={Math.round(modelExecutions.reduce((sum, model) => sum + model.totalSize, 0) / (1024 * 1024 * 1024))} 
-                duration={1500} 
-              />
-              <span className="text-sm font-normal">GB</span>
-            </div>
-            <div className="text-sm text-muted-foreground">Total Model Size</div>
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* Filters and Controls */}
-      <div className="max-w-6xl mx-auto mb-8">
-        <Card>
-          <CardHeader>
-            <div className="flex items-center justify-between">
-              <CardTitle className="text-lg flex items-center gap-2">
-                <Filter className="h-5 w-5" />
-                Filters & Controls
-              </CardTitle>
-              <Button
-                onClick={handleRefresh}
-                disabled={refreshing}
-                size="sm"
-                variant="outline"
-                className="gap-2"
-              >
-                <RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />
-                {refreshing ? 'Refreshing...' : 'Refresh'}
-              </Button>
-            </div>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
-              {/* Search */}
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                <Input
-                  placeholder="Search models..."
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  className="pl-10"
-                />
-              </div>
-
-              {/* Server Filter */}
-              <Select value={serverFilter} onValueChange={setServerFilter}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Filter by server" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All Servers</SelectItem>
-                  {uniqueServers.slice(0, 20).map(server => (
-                    <SelectItem key={server} value={server}>{server}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-
-              {/* Status Filter */}
-              <Select value={statusFilter} onValueChange={(value: StatusFilter) => setStatusFilter(value)}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Filter by status" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All Status</SelectItem>
-                  <SelectItem value="running">Currently Running</SelectItem>
-                  <SelectItem value="stopped">Available but Stopped</SelectItem>
-                  <SelectItem value="available">Available on Servers</SelectItem>
-                </SelectContent>
-              </Select>
-
-              {/* Sort By */}
-              <Select value={sortBy} onValueChange={(value: SortOption) => setSortBy(value)}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Sort by" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="name">Model Name</SelectItem>
-                  <SelectItem value="servers">Server Count</SelectItem>
-                  <SelectItem value="running">Running Count</SelectItem>
-                  <SelectItem value="frequency">Execution Frequency</SelectItem>
-                  <SelectItem value="size">Average Size</SelectItem>
-                </SelectContent>
-              </Select>
-
-              {/* Sort Direction */}
-              <Button
-                variant="outline"
-                onClick={() => setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc')}
-                className="gap-2"
-              >
-                {sortDirection === 'asc' ? <SortAsc className="h-4 w-4" /> : <SortDesc className="h-4 w-4" />}
-                {sortDirection === 'asc' ? 'Ascending' : 'Descending'}
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* Model List */}
-      <div id="models-section" className="space-y-4 max-w-6xl mx-auto">
-        {/* Results Summary */}
-        {filteredAndSortedModels.length > 0 && (
-          <div className="flex items-center justify-between mb-6">
-            <div className="text-sm text-muted-foreground">
-              Showing {indexOfFirstModel + 1}-{Math.min(indexOfLastModel, filteredAndSortedModels.length)} of {filteredAndSortedModels.length} models
-            </div>
-            <div className="text-sm text-muted-foreground">
-              Page {currentPage} of {totalPages}
-            </div>
-          </div>
-        )}
-
-        {filteredAndSortedModels.length === 0 ? (
-          <Card>
-            <CardContent className="text-center py-12">
-              <Database className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
-              <h3 className="text-lg font-semibold mb-2">No Models Found</h3>
-              <p className="text-muted-foreground">
-                Try adjusting your filters or search terms to find models.
-              </p>
-            </CardContent>
-          </Card>
-        ) : (
-          currentModels.map((model) => (
-            <Card key={model.modelName} className="overflow-hidden">
-              <Collapsible
-                open={expandedModels.has(model.modelName)}
-                onOpenChange={() => toggleModelExpansion(model.modelName)}
-              >
-                <CollapsibleTrigger asChild>
-                  <CardHeader className="cursor-pointer hover:bg-muted/50 transition-colors">
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-4">
-                        <div className="flex items-center gap-2">
-                          {expandedModels.has(model.modelName) ? 
-                            <ChevronUp className="h-5 w-5" /> : 
-                            <ChevronDown className="h-5 w-5" />
-                          }
-                          <CardTitle className="text-xl">{model.modelName}</CardTitle>
-                        </div>
-                        
-                        <div className="flex items-center gap-2">
-                          {model.runningServers > 0 ? (
-                            <Badge variant="default" className="bg-green-500 gap-1">
-                              <Play className="h-3 w-3" />
-                              {model.runningServers} Running
-                            </Badge>
-                          ) : (
-                            <Badge variant="secondary" className="gap-1">
-                              <Square className="h-3 w-3" />
-                              Stopped
-                            </Badge>
-                          )}
-                          
-                          <Badge variant="outline" className="gap-1">
-                            <Server className="h-3 w-3" />
-                            {model.totalServers} Servers
-                          </Badge>
-                          
-                          <Badge variant="outline" className="gap-1">
-                            <HardDrive className="h-3 w-3" />
-                            {formatSize(model.averageSize)} avg
-                          </Badge>
-                        </div>
-                      </div>
-
-                      <div className="text-right">
-                        <div className="text-sm text-muted-foreground flex items-center gap-1">
-                          <Clock className="h-3 w-3" />
-                          Last seen {formatTimestamp(model.lastActivity)}
-                        </div>
-                        <div className="text-xs text-muted-foreground">
-                          {Math.round(model.executionFrequency * 100)}% execution rate
-                        </div>
-                      </div>
-                    </div>
-                  </CardHeader>
-                </CollapsibleTrigger>
-
-                <CollapsibleContent>
-                  <CardContent className="pt-0">
-                    <div className="space-y-4">
-                      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 p-4 bg-muted/20 rounded-lg">
-                        <div className="text-center">
-                          <div className="text-2xl font-bold text-primary">{model.totalServers}</div>
-                          <div className="text-sm text-muted-foreground">Total Servers</div>
-                        </div>
-                        <div className="text-center">
-                          <div className="text-2xl font-bold text-green-500">{model.runningServers}</div>
-                          <div className="text-sm text-muted-foreground">Currently Running</div>
-                        </div>
-                        <div className="text-center">
-                          <div className="text-2xl font-bold text-blue-500">{formatSize(model.totalSize)}</div>
-                          <div className="text-sm text-muted-foreground">Total Size</div>
-                        </div>
-                      </div>
-
-                      <div>
-                        <h4 className="font-semibold mb-3 flex items-center gap-2">
-                          <Server className="h-4 w-4" />
-                          Server Locations ({model.servers.length})
-                        </h4>
-                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-                          {model.servers.map((serverInfo, index) => (
-                            <Card key={`${serverInfo.server.ip}-${serverInfo.server.port}-${index}`} className="p-4">
-                              <div className="space-y-2">
-                                <div className="flex items-center justify-between">
-                                  <div className="font-mono text-sm">
-                                    {serverInfo.server.ip}:{serverInfo.server.port}
-                                  </div>
-                                  <div className="flex items-center gap-2">
-                                    {serverInfo.isRunning ? (
-                                      <Badge variant="default" className="bg-green-500 gap-1">
-                                        <Play className="h-3 w-3" />
-                                        Running
-                                      </Badge>
-                                    ) : (
-                                      <Badge variant="secondary" className="gap-1">
-                                        <Square className="h-3 w-3" />
-                                        Available
-                                      </Badge>
-                                    )}
-                                  </div>
-                                </div>
-                                
-                                <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                                  <span>{getCountryFlag(serverInfo.server.country)}</span>
-                                  <span>{serverInfo.server.city}, {serverInfo.server.country_name}</span>
-                                </div>
-                                
-                                <div className="flex items-center justify-between text-xs text-muted-foreground">
-                                  <span className="flex items-center gap-1">
-                                    <HardDrive className="h-3 w-3" />
-                                    {formatSize(serverInfo.modelSize)}
-                                  </span>
-                                  <span className="flex items-center gap-1">
-                                    <Clock className="h-3 w-3" />
-                                    {formatTimestamp(serverInfo.lastSeen)}
-                                  </span>
-                                </div>
-                                
-                                <div className="text-xs text-muted-foreground">
-                                  Version: {serverInfo.server.version} | 
-                                  Status: {serverInfo.server.status}
-                                </div>
-                              </div>
-                            </Card>
-                          ))}
-                        </div>
-                      </div>
-                    </div>
-                  </CardContent>
-                </CollapsibleContent>
-              </Collapsible>
-            </Card>
-          ))
-        )}
-      </div>
-
-      {/* Pagination Controls */}
-      {totalPages > 1 && (
-        <div className="flex justify-center mt-8">
-          <Pagination>
-            <PaginationContent>
-              <PaginationItem>
-                <PaginationPrevious 
-                  onClick={() => handlePageChange(Math.max(1, currentPage - 1))}
-                  className={currentPage === 1 ? 'pointer-events-none opacity-50' : 'cursor-pointer'}
-                />
-              </PaginationItem>
-              
-              {/* First page */}
-              {currentPage > 3 && (
-                <>
-                  <PaginationItem>
-                    <PaginationLink 
-                      onClick={() => handlePageChange(1)}
-                      isActive={currentPage === 1}
-                      className="cursor-pointer"
-                    >
-                      1
-                    </PaginationLink>
-                  </PaginationItem>
-                  {currentPage > 4 && (
-                    <PaginationItem>
-                      <PaginationEllipsis />
-                    </PaginationItem>
-                  )}
-                </>
-              )}
-              
-              {/* Page numbers around current page */}
-              {Array.from({ length: totalPages }, (_, i) => i + 1)
-                .filter(page => {
-                  return page >= Math.max(1, currentPage - 2) && 
-                         page <= Math.min(totalPages, currentPage + 2);
-                })
-                .map(page => (
-                  <PaginationItem key={page}>
-                    <PaginationLink 
-                      onClick={() => handlePageChange(page)}
-                      isActive={currentPage === page}
-                      className="cursor-pointer"
-                    >
-                      {page}
-                    </PaginationLink>
-                  </PaginationItem>
-                ))}
-              
-              {/* Last page */}
-              {currentPage < totalPages - 2 && (
-                <>
-                  {currentPage < totalPages - 3 && (
-                    <PaginationItem>
-                      <PaginationEllipsis />
-                    </PaginationItem>
-                  )}
-                  <PaginationItem>
-                    <PaginationLink 
-                      onClick={() => handlePageChange(totalPages)}
-                      isActive={currentPage === totalPages}
-                      className="cursor-pointer"
-                    >
-                      {totalPages}
-                    </PaginationLink>
-                  </PaginationItem>
-                </>
-              )}
-              
-              <PaginationItem>
-                <PaginationNext 
-                  onClick={() => handlePageChange(Math.min(totalPages, currentPage + 1))}
-                  className={currentPage === totalPages ? 'pointer-events-none opacity-50' : 'cursor-pointer'}
-                />
-              </PaginationItem>
-            </PaginationContent>
-          </Pagination>
-        </div>
-      )}
-
-      {/* Footer Info */}
+    <BasePage loading={loading} error={error} retry={() => fetchServerData()}>
+      <SummaryStats modelExecutions={modelExecutions} serverData={serverData} />
+      <FilterControls
+        searchTerm={searchTerm}
+        setSearchTerm={setSearchTerm}
+        serverFilter={serverFilter}
+        setServerFilter={setServerFilter}
+        statusFilter={statusFilter}
+        setStatusFilter={setStatusFilter}
+        sortBy={sortBy}
+        setSortBy={setSortBy}
+        sortDirection={sortDirection}
+        setSortDirection={setSortDirection}
+        uniqueServers={uniqueServers}
+        refreshing={refreshing}
+        handleRefresh={handleRefresh}
+      />
+      <ModelList
+        models={currentModels}
+        expandedModels={expandedModels}
+        toggleModelExpansion={toggleModelExpansion}
+        indexOfFirstModel={indexOfFirstModel}
+        indexOfLastModel={indexOfLastModel}
+        totalModels={filteredAndSortedModels.length}
+        currentPage={currentPage}
+        totalPages={totalPages}
+      />
+      <PaginationControls
+        currentPage={currentPage}
+        totalPages={totalPages}
+        handlePageChange={handlePageChange}
+      />
       <div className="text-center mt-12">
         <p className="text-sm text-muted-foreground">
-          Data refreshes automatically every 30 seconds. Last updated: {formatTimestamp(new Date().toISOString())}
+          Data refreshes automatically every 30 seconds. Last updated: {formatDistanceToNowStrict(new Date(), { addSuffix: true })}
         </p>
       </div>
-    </section>
+    </BasePage>
   );
 };
 

--- a/frontend/src/components/ModelExecutionDashboard.tsx
+++ b/frontend/src/components/ModelExecutionDashboard.tsx
@@ -6,6 +6,7 @@ import FilterControls from './dashboard/FilterControls';
 import ModelList from './dashboard/ModelList';
 import PaginationControls from './dashboard/PaginationControls';
 import { formatDistanceToNowStrict } from "date-fns";
+import { calculateActiveExecutions, calculateTotalModelSize } from '@/utils/stats-calculator';
 
 const ModelExecutionDashboard = () => {
   const [serverData, setServerData] = useState<ServerData[]>([]);
@@ -69,13 +70,13 @@ const ModelExecutionDashboard = () => {
         if (!modelMap.has(key)) {
           modelMap.set(key, {
             modelName: model.name,
+            averageSize: 0,
             totalServers: 0,
             runningServers: 0,
             totalSize: 0,
-            averageSize: 0,
             servers: [],
             lastActivity: server.last_observed,
-            executionFrequency: 0
+            executionFrequency: 0,
           });
         }
         
@@ -106,13 +107,13 @@ const ModelExecutionDashboard = () => {
         if (!modelMap.has(key)) {
           modelMap.set(key, {
             modelName: model.name,
+            averageSize: 0,
             totalServers: 0,
             runningServers: 0,
             totalSize: 0,
-            averageSize: 0,
             servers: [],
             lastActivity: server.last_observed,
-            executionFrequency: 0
+            executionFrequency: 0,
           });
         }
         
@@ -259,9 +260,17 @@ const ModelExecutionDashboard = () => {
     return Array.from(servers).sort();
   }, [serverData]);
 
+  const activeExecutions = useMemo(() => calculateActiveExecutions(modelExecutions), [modelExecutions]);
+  const totalModelSize = useMemo(() => calculateTotalModelSize(modelExecutions), [modelExecutions]);
+
   return (
     <BasePage loading={loading} error={error} retry={() => fetchServerData()}>
-      <SummaryStats modelExecutions={modelExecutions} serverData={serverData} />
+      <SummaryStats
+        modelExecutions={modelExecutions}
+        serverData={serverData}
+        activeExecutions={activeExecutions}
+        totalModelSize={totalModelSize}
+      />
       <FilterControls
         searchTerm={searchTerm}
         setSearchTerm={setSearchTerm}

--- a/frontend/src/components/dashboard/BasePage.tsx
+++ b/frontend/src/components/dashboard/BasePage.tsx
@@ -12,18 +12,21 @@ const DashboardHeader = () => {
         {/* Haiku */}
         <div className="max-w-md mx-auto p-4 bg-gradient-to-r from-blue-500/10 to-purple-500/10 border border-blue-500/20 rounded-lg">
           <div className="text-sm font-mono text-muted-foreground italic leading-relaxed">
-            No keys, no limits here.
-            AI models run wild and free.
-            Internet's playground.
+            <div>No keys, no limits here</div>
+            <div>AI models run wild and free—</div>
+            <div>Internet's playground</div>
           </div>
         </div>
 
         {/* Body copy */}
         <div className="text-muted-foreground max-w-3xl mx-auto space-y-2">
-          <p className="text-sm font-mono italic leading-relaxed">
-            "Choose your AI model!"
-            Developers cry, you click
-            Who made this dashboard?
+          <p>
+            Welcome to the wild west of AI, where LLM servers roam free without authentication, rate limits, or adult supervision.
+            These beautifully exposed endpoints are running everything from creative writing assistants to code generators—all waiting for your prompts.
+          </p>
+          <p className="text-sm">
+            What makes them special? Zero barriers, infinite possibilities, and the kind of open access that would make security teams weep.
+            Perfect for experimentation, research, or just seeing what happens when AI meets the honor system.
           </p>
         </div>
       </div>

--- a/frontend/src/components/dashboard/BasePage.tsx
+++ b/frontend/src/components/dashboard/BasePage.tsx
@@ -12,21 +12,18 @@ const DashboardHeader = () => {
         {/* Haiku */}
         <div className="max-w-md mx-auto p-4 bg-gradient-to-r from-blue-500/10 to-purple-500/10 border border-blue-500/20 rounded-lg">
           <div className="text-sm font-mono text-muted-foreground italic leading-relaxed">
-            <div>No keys, no limits here</div>
-            <div>AI models run wild and free—</div>
-            <div>Internet's playground</div>
+            No keys, no limits here.
+            AI models run wild and free.
+            Internet's playground.
           </div>
         </div>
 
         {/* Body copy */}
         <div className="text-muted-foreground max-w-3xl mx-auto space-y-2">
-          <p>
-            Welcome to the wild west of AI, where LLM servers roam free without authentication, rate limits, or adult supervision.
-            These beautifully exposed endpoints are running everything from creative writing assistants to code generators—all waiting for your prompts.
-          </p>
-          <p className="text-sm">
-            What makes them special? Zero barriers, infinite possibilities, and the kind of open access that would make security teams weep.
-            Perfect for experimentation, research, or just seeing what happens when AI meets the honor system.
+          <p className="text-sm font-mono italic leading-relaxed">
+            "Choose your AI model!"
+            Developers cry, you click
+            Who made this dashboard?
           </p>
         </div>
       </div>

--- a/frontend/src/components/dashboard/BasePage.tsx
+++ b/frontend/src/components/dashboard/BasePage.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { Button } from "@/components/ui/button";
+import { RefreshCw } from "lucide-react";
+
+const DashboardHeader = () => {
+    return (
+      <div className="text-center space-y-4 mb-12">
+        <h2 className="text-2xl font-bold tracking-tight md:text-3xl">
+          Model Execution Dashboard 🚀
+        </h2>
+
+        {/* Haiku */}
+        <div className="max-w-md mx-auto p-4 bg-gradient-to-r from-blue-500/10 to-purple-500/10 border border-blue-500/20 rounded-lg">
+          <div className="text-sm font-mono text-muted-foreground italic leading-relaxed">
+            <div>No keys, no limits here</div>
+            <div>AI models run wild and free—</div>
+            <div>Internet's playground</div>
+          </div>
+        </div>
+
+        {/* Body copy */}
+        <div className="text-muted-foreground max-w-3xl mx-auto space-y-2">
+          <p>
+            Welcome to the wild west of AI, where LLM servers roam free without authentication, rate limits, or adult supervision.
+            These beautifully exposed endpoints are running everything from creative writing assistants to code generators—all waiting for your prompts.
+          </p>
+          <p className="text-sm">
+            What makes them special? Zero barriers, infinite possibilities, and the kind of open access that would make security teams weep.
+            Perfect for experimentation, research, or just seeing what happens when AI meets the honor system.
+          </p>
+        </div>
+      </div>
+    );
+  };
+
+const LoadingSpinner = () => {
+    return (
+      <section className="container py-16">
+        <div className="text-center space-y-4 mb-12">
+          <h2 className="text-2xl font-bold tracking-tight md:text-3xl">
+            Model Execution Dashboard
+          </h2>
+          <p className="text-muted-foreground max-w-2xl mx-auto">
+            Loading model execution data across all servers...
+          </p>
+        </div>
+
+        <div className="space-y-4 max-w-6xl mx-auto">
+          {[1, 2, 3].map((index) => (
+            <div
+              key={index}
+              className="relative p-6 rounded-lg border backdrop-blur-sm bg-muted/20 border-muted animate-pulse"
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-4">
+                  <div className="h-6 bg-muted rounded w-32"></div>
+                  <div className="h-4 bg-muted rounded w-20"></div>
+                </div>
+                <div className="text-right space-y-2">
+                  <div className="h-4 bg-muted rounded w-24"></div>
+                  <div className="h-4 bg-muted rounded w-20"></div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    );
+  };
+
+  interface ErrorMessageProps {
+    error: string;
+    retry: () => void;
+  }
+
+  const ErrorMessage: React.FC<ErrorMessageProps> = ({ error, retry }) => {
+    return (
+      <section className="container py-16">
+        <div className="text-center">
+          <h2 className="text-2xl font-bold tracking-tight md:text-3xl mb-4">
+            Model Execution Dashboard
+          </h2>
+          <p className="text-destructive mb-2">Failed to load model execution data</p>
+          <p className="text-xs text-muted-foreground">{error}</p>
+          <Button onClick={retry} className="mt-4">
+            <RefreshCw className="h-4 w-4 mr-2" />
+            Retry
+          </Button>
+        </div>
+      </section>
+    );
+  };
+
+interface BasePageProps {
+    children: React.ReactNode;
+    loading: boolean;
+    error: string | null;
+    retry: () => void;
+  }
+
+const BasePage: React.FC<BasePageProps> = ({ children, loading, error, retry }) => {
+  if (loading) {
+    return <LoadingSpinner />;
+  }
+
+  if (error) {
+    return <ErrorMessage error={error} retry={retry} />;
+  }
+
+  return (
+    <section className="container py-16">
+      <DashboardHeader />
+      {children}
+    </section>
+  );
+};
+
+export default BasePage;

--- a/frontend/src/components/dashboard/FilterControls.tsx
+++ b/frontend/src/components/dashboard/FilterControls.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Search,
+  Filter,
+  SortAsc,
+  SortDesc,
+  RefreshCw,
+} from "lucide-react";
+import { SortOption, SortDirection, StatusFilter } from '@/types/ModelExecution';
+
+interface FilterControlsProps {
+  searchTerm: string;
+  setSearchTerm: (value: string) => void;
+  serverFilter: string;
+  setServerFilter: (value: string) => void;
+  statusFilter: StatusFilter;
+  setStatusFilter: (value: StatusFilter) => void;
+  sortBy: SortOption;
+  setSortBy: (value: SortOption) => void;
+  sortDirection: SortDirection;
+  setSortDirection: (value: SortDirection) => void;
+  uniqueServers: string[];
+  refreshing: boolean;
+  handleRefresh: () => void;
+}
+
+const FilterControls: React.FC<FilterControlsProps> = ({
+  searchTerm,
+  setSearchTerm,
+  serverFilter,
+  setServerFilter,
+  statusFilter,
+  setStatusFilter,
+  sortBy,
+  setSortBy,
+  sortDirection,
+  setSortDirection,
+  uniqueServers,
+  refreshing,
+  handleRefresh,
+}) => {
+  return (
+    <div className="max-w-6xl mx-auto mb-8">
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-lg flex items-center gap-2">
+              <Filter className="h-5 w-5" />
+              Filters & Controls
+            </CardTitle>
+            <Button
+              onClick={handleRefresh}
+              disabled={refreshing}
+              size="sm"
+              variant="outline"
+              className="gap-2"
+            >
+              <RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />
+              {refreshing ? 'Refreshing...' : 'Refresh'}
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+            {/* Search */}
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Search models..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="pl-10"
+              />
+            </div>
+
+            {/* Server Filter */}
+            <Select value={serverFilter} onValueChange={setServerFilter}>
+              <SelectTrigger>
+                <SelectValue placeholder="Filter by server" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Servers</SelectItem>
+                {uniqueServers.slice(0, 20).map(server => (
+                  <SelectItem key={server} value={server}>{server}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            {/* Status Filter */}
+            <Select value={statusFilter} onValueChange={(value: StatusFilter) => setStatusFilter(value)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Filter by status" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Status</SelectItem>
+                <SelectItem value="running">Currently Running</SelectItem>
+                <SelectItem value="stopped">Available but Stopped</SelectItem>
+                <SelectItem value="available">Available on Servers</SelectItem>
+              </SelectContent>
+            </Select>
+
+            {/* Sort By */}
+            <Select value={sortBy} onValueChange={(value: SortOption) => setSortBy(value)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Sort by" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="name">Model Name</SelectItem>
+                <SelectItem value="servers">Server Count</SelectItem>
+                <SelectItem value="running">Running Count</SelectItem>
+                <SelectItem value="frequency">Execution Frequency</SelectItem>
+                <SelectItem value="size">Average Size</SelectItem>
+              </SelectContent>
+            </Select>
+
+            {/* Sort Direction */}
+            <Button
+              variant="outline"
+              onClick={() => setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc')}
+              className="gap-2"
+            >
+              {sortDirection === 'asc' ? <SortAsc className="h-4 w-4" /> : <SortDesc className="h-4 w-4" />}
+              {sortDirection === 'asc' ? 'Ascending' : 'Descending'}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default FilterControls;

--- a/frontend/src/components/dashboard/ModelCard.tsx
+++ b/frontend/src/components/dashboard/ModelCard.tsx
@@ -12,7 +12,7 @@ import {
   HardDrive
 } from "lucide-react";
 import { formatDistanceToNowStrict } from "date-fns";
-import { ModelExecution } from '@/types/ModelExecution';
+import { ModelExecution, ModelMetadata, ServerAggregation, ExecutionStatistics } from '@/types/ModelExecution';
 
 interface ModelCardProps {
   model: ModelExecution;

--- a/frontend/src/components/dashboard/ModelCard.tsx
+++ b/frontend/src/components/dashboard/ModelCard.tsx
@@ -129,7 +129,7 @@ const ModelCard: React.FC<ModelCardProps> = ({ model, isExpanded, toggleExpansio
                 </h4>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
                   {model.servers.map((serverInfo, index) => (
-                    <Card key={`${serverInfo.server.ip}-${serverInfo.server.port}`} className="p-4">
+                    <Card key={`${serverInfo.server.ip}-${serverInfo.server.port}-${index}`} className="p-4">
                       <div className="space-y-2">
                         <div className="flex items-center justify-between">
                           <div className="font-mono text-sm">

--- a/frontend/src/components/dashboard/ModelCard.tsx
+++ b/frontend/src/components/dashboard/ModelCard.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import {
+  ChevronDown,
+  ChevronUp,
+  Play,
+  Square,
+  Server,
+  Clock,
+  HardDrive
+} from "lucide-react";
+import { formatDistanceToNowStrict } from "date-fns";
+import { ModelExecution } from '@/types/ModelExecution';
+
+interface ModelCardProps {
+  model: ModelExecution;
+  isExpanded: boolean;
+  toggleExpansion: (modelName: string) => void;
+}
+
+const formatSize = (bytes: number) => {
+  const gb = bytes / (1024 * 1024 * 1024);
+  if (gb >= 1) {
+    return `${gb.toFixed(1)}GB`;
+  }
+  const mb = bytes / (1024 * 1024);
+  return `${mb.toFixed(0)}MB`;
+};
+
+const formatTimestamp = (dateString: string) => {
+  try {
+    const date = new Date(dateString);
+    return formatDistanceToNowStrict(date, { addSuffix: true });
+  } catch {
+    return 'Unknown';
+  }
+};
+
+const getCountryFlag = (countryCode: string) => {
+  const flags: { [key: string]: string } = {
+    'CN': '🇨🇳', 'JP': '🇯🇵', 'GB': '🇬🇧', 'RU': '🇷🇺', 'US': '🇺🇸',
+    'DE': '🇩🇪', 'FR': '🇫🇷', 'IT': '🇮🇹', 'ES': '🇪🇸', 'CA': '🇨🇦',
+    'AU': '🇦🇺', 'BR': '🇧🇷', 'IN': '🇮🇳', 'KR': '🇰🇷'
+  };
+  return flags[countryCode] || '🌍';
+};
+
+const ModelCard: React.FC<ModelCardProps> = ({ model, isExpanded, toggleExpansion }) => {
+  return (
+    <Card key={model.modelName} className="overflow-hidden">
+      <Collapsible
+        open={isExpanded}
+        onOpenChange={() => toggleExpansion(model.modelName)}
+      >
+        <CollapsibleTrigger asChild>
+          <CardHeader className="cursor-pointer hover:bg-muted/50 transition-colors">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-4">
+                <div className="flex items-center gap-2">
+                  {isExpanded ?
+                    <ChevronUp className="h-5 w-5" /> :
+                    <ChevronDown className="h-5 w-5" />
+                  }
+                  <CardTitle className="text-xl">{model.modelName}</CardTitle>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  {model.runningServers > 0 ? (
+                    <Badge variant="default" className="bg-green-500 gap-1">
+                      <Play className="h-3 w-3" />
+                      {model.runningServers} Running
+                    </Badge>
+                  ) : (
+                    <Badge variant="secondary" className="gap-1">
+                      <Square className="h-3 w-3" />
+                      Stopped
+                    </Badge>
+                  )}
+
+                  <Badge variant="outline" className="gap-1">
+                    <Server className="h-3 w-3" />
+                    {model.totalServers} Servers
+                  </Badge>
+
+                  <Badge variant="outline" className="gap-1">
+                    <HardDrive className="h-3 w-3" />
+                    {formatSize(model.averageSize)} avg
+                  </Badge>
+                </div>
+              </div>
+
+              <div className="text-right">
+                <div className="text-sm text-muted-foreground flex items-center gap-1">
+                  <Clock className="h-3 w-3" />
+                  Last seen {formatTimestamp(model.lastActivity)}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {Math.round(model.executionFrequency * 100)}% execution rate
+                </div>
+              </div>
+            </div>
+          </CardHeader>
+        </CollapsibleTrigger>
+
+        <CollapsibleContent>
+          <CardContent className="pt-0">
+            <div className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4 p-4 bg-muted/20 rounded-lg">
+                <div className="text-center">
+                  <div className="text-2xl font-bold text-primary">{model.totalServers}</div>
+                  <div className="text-sm text-muted-foreground">Total Servers</div>
+                </div>
+                <div className="text-center">
+                  <div className="text-2xl font-bold text-green-500">{model.runningServers}</div>
+                  <div className="text-sm text-muted-foreground">Currently Running</div>
+                </div>
+                <div className="text-center">
+                  <div className="text-2xl font-bold text-blue-500">{formatSize(model.totalSize)}</div>
+                  <div className="text-sm text-muted-foreground">Total Size</div>
+                </div>
+              </div>
+
+              <div>
+                <h4 className="font-semibold mb-3 flex items-center gap-2">
+                  <Server className="h-4 w-4" />
+                  Server Locations ({model.servers.length})
+                </h4>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                  {model.servers.map((serverInfo, index) => (
+                    <Card key={`${serverInfo.server.ip}-${serverInfo.server.port}-${index}`} className="p-4">
+                      <div className="space-y-2">
+                        <div className="flex items-center justify-between">
+                          <div className="font-mono text-sm">
+                            {serverInfo.server.ip}:{serverInfo.server.port}
+                          </div>
+                          <div className="flex items-center gap-2">
+                            {serverInfo.isRunning ? (
+                              <Badge variant="default" className="bg-green-500 gap-1">
+                                <Play className="h-3 w-3" />
+                                Running
+                              </Badge>
+                            ) : (
+                              <Badge variant="secondary" className="gap-1">
+                                <Square className="h-3 w-3" />
+                                Available
+                              </Badge>
+                            )}
+                          </div>
+                        </div>
+
+                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                          <span>{getCountryFlag(serverInfo.server.country)}</span>
+                          <span>{serverInfo.server.city}, {serverInfo.server.country_name}</span>
+                        </div>
+
+                        <div className="flex items-center justify-between text-xs text-muted-foreground">
+                          <span className="flex items-center gap-1">
+                            <HardDrive className="h-3 w-3" />
+                            {formatSize(serverInfo.modelSize)}
+                          </span>
+                          <span className="flex items-center gap-1">
+                            <Clock className="h-3 w-3" />
+                            {formatTimestamp(serverInfo.lastSeen)}
+                          </span>
+                        </div>
+
+                        <div className="text-xs text-muted-foreground">
+                          Version: {serverInfo.server.version} |
+                          Status: {serverInfo.server.status}
+                        </div>
+                      </div>
+                    </Card>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </CollapsibleContent>
+      </Collapsible>
+    </Card>
+  );
+};
+
+export default ModelCard;

--- a/frontend/src/components/dashboard/ModelCard.tsx
+++ b/frontend/src/components/dashboard/ModelCard.tsx
@@ -129,7 +129,7 @@ const ModelCard: React.FC<ModelCardProps> = ({ model, isExpanded, toggleExpansio
                 </h4>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
                   {model.servers.map((serverInfo, index) => (
-                    <Card key={`${serverInfo.server.ip}-${serverInfo.server.port}-${index}`} className="p-4">
+                    <Card key={`${serverInfo.server.ip}-${serverInfo.server.port}`} className="p-4">
                       <div className="space-y-2">
                         <div className="flex items-center justify-between">
                           <div className="font-mono text-sm">

--- a/frontend/src/components/dashboard/ModelList.tsx
+++ b/frontend/src/components/dashboard/ModelList.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Card, CardContent } from "@/components/ui/card";
+import { Database } from "lucide-react";
+import ModelCard from './ModelCard';
+import { ModelExecution } from '@/types/ModelExecution';
+
+interface ModelListProps {
+  models: ModelExecution[];
+  expandedModels: Set<string>;
+  toggleModelExpansion: (modelName: string) => void;
+  indexOfFirstModel: number;
+  indexOfLastModel: number;
+  totalModels: number;
+  currentPage: number;
+  totalPages: number;
+}
+
+const ModelList: React.FC<ModelListProps> = ({
+  models,
+  expandedModels,
+  toggleModelExpansion,
+  indexOfFirstModel,
+  indexOfLastModel,
+  totalModels,
+  currentPage,
+  totalPages,
+}) => {
+  return (
+    <div id="models-section" className="space-y-4 max-w-6xl mx-auto">
+      {/* Results Summary */}
+      {totalModels > 0 && (
+        <div className="flex items-center justify-between mb-6">
+          <div className="text-sm text-muted-foreground">
+            Showing {indexOfFirstModel + 1}-{Math.min(indexOfLastModel, totalModels)} of {totalModels} models
+          </div>
+          <div className="text-sm text-muted-foreground">
+            Page {currentPage} of {totalPages}
+          </div>
+        </div>
+      )}
+
+      {models.length === 0 ? (
+        <Card>
+          <CardContent className="text-center py-12">
+            <Database className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
+            <h3 className="text-lg font-semibold mb-2">No Models Found</h3>
+            <p className="text-muted-foreground">
+              Try adjusting your filters or search terms to find models.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        models.map((model) => (
+          <ModelCard
+            key={model.modelName}
+            model={model}
+            isExpanded={expandedModels.has(model.modelName)}
+            toggleExpansion={toggleModelExpansion}
+          />
+        ))
+      )}
+    </div>
+  );
+};
+
+export default ModelList;

--- a/frontend/src/components/dashboard/PaginationControls.tsx
+++ b/frontend/src/components/dashboard/PaginationControls.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+  PaginationEllipsis,
+} from "@/components/ui/pagination";
+
+interface PaginationControlsProps {
+  currentPage: number;
+  totalPages: number;
+  handlePageChange: (page: number) => void;
+}
+
+const PaginationControls: React.FC<PaginationControlsProps> = ({ currentPage, totalPages, handlePageChange }) => {
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  return (
+    <div className="flex justify-center mt-8">
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious
+              onClick={() => handlePageChange(Math.max(1, currentPage - 1))}
+              className={currentPage === 1 ? 'pointer-events-none opacity-50' : 'cursor-pointer'}
+            />
+          </PaginationItem>
+
+          {/* First page */}
+          {currentPage > 3 && (
+            <>
+              <PaginationItem>
+                <PaginationLink
+                  onClick={() => handlePageChange(1)}
+                  isActive={currentPage === 1}
+                  className="cursor-pointer"
+                >
+                  1
+                </PaginationLink>
+              </PaginationItem>
+              {currentPage > 4 && (
+                <PaginationItem>
+                  <PaginationEllipsis />
+                </PaginationItem>
+              )}
+            </>
+          )}
+
+          {/* Page numbers around current page */}
+          {Array.from({ length: totalPages }, (_, i) => i + 1)
+            .filter(page => {
+              return page >= Math.max(1, currentPage - 2) &&
+                     page <= Math.min(totalPages, currentPage + 2);
+            })
+            .map(page => (
+              <PaginationItem key={page}>
+                <PaginationLink
+                  onClick={() => handlePageChange(page)}
+                  isActive={currentPage === page}
+                  className="cursor-pointer"
+                >
+                  {page}
+                </PaginationLink>
+              </PaginationItem>
+            ))}
+
+          {/* Last page */}
+          {currentPage < totalPages - 2 && (
+            <>
+              {currentPage < totalPages - 3 && (
+                <PaginationItem>
+                  <PaginationEllipsis />
+                </PaginationItem>
+              )}
+              <PaginationItem>
+                <PaginationLink
+                  onClick={() => handlePageChange(totalPages)}
+                  isActive={currentPage === totalPages}
+                  className="cursor-pointer"
+                >
+                  {totalPages}
+                </PaginationLink>
+              </PaginationItem>
+            </>
+          )}
+
+          <PaginationItem>
+            <PaginationNext
+              onClick={() => handlePageChange(Math.min(totalPages, currentPage + 1))}
+              className={currentPage === totalPages ? 'pointer-events-none opacity-50' : 'cursor-pointer'}
+            />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    </div>
+  );
+};
+
+export default PaginationControls;

--- a/frontend/src/components/dashboard/SummaryStats.tsx
+++ b/frontend/src/components/dashboard/SummaryStats.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Card, CardContent } from "@/components/ui/card";
+import AnimatedCounter from '../AnimatedCounter';
+import { ModelExecution, ServerData } from '@/types/ModelExecution';
+
+interface SummaryStatsProps {
+  modelExecutions: ModelExecution[];
+  serverData: ServerData[];
+}
+
+const SummaryStats: React.FC<SummaryStatsProps> = ({ modelExecutions, serverData }) => {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8 max-w-4xl mx-auto">
+      <Card className="text-center">
+        <CardContent className="pt-6">
+          <div className="text-2xl font-bold text-primary">
+            <AnimatedCounter target={modelExecutions.length} duration={1500} />
+          </div>
+          <div className="text-sm text-muted-foreground">Unique Models</div>
+        </CardContent>
+      </Card>
+
+      <Card className="text-center">
+        <CardContent className="pt-6">
+          <div className="text-2xl font-bold text-green-500">
+            <AnimatedCounter
+              target={modelExecutions.reduce((sum, model) => sum + model.runningServers, 0)}
+              duration={1500}
+            />
+          </div>
+          <div className="text-sm text-muted-foreground">Active Executions</div>
+        </CardContent>
+      </Card>
+
+      <Card className="text-center">
+        <CardContent className="pt-6">
+          <div className="text-2xl font-bold text-blue-500">
+            <AnimatedCounter target={serverData.length} duration={1500} />
+          </div>
+          <div className="text-sm text-muted-foreground">Total Servers</div>
+        </CardContent>
+      </Card>
+
+      <Card className="text-center">
+        <CardContent className="pt-6">
+          <div className="text-2xl font-bold text-orange-500">
+            <AnimatedCounter
+              target={Math.round(modelExecutions.reduce((sum, model) => sum + model.totalSize, 0) / (1024 * 1024 * 1024))}
+              duration={1500}
+            />
+            <span className="text-sm font-normal">GB</span>
+          </div>
+          <div className="text-sm text-muted-foreground">Total Model Size</div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default SummaryStats;

--- a/frontend/src/components/dashboard/SummaryStats.tsx
+++ b/frontend/src/components/dashboard/SummaryStats.tsx
@@ -6,9 +6,11 @@ import { ModelExecution, ServerData } from '@/types/ModelExecution';
 interface SummaryStatsProps {
   modelExecutions: ModelExecution[];
   serverData: ServerData[];
+  activeExecutions: number;
+  totalModelSize: number;
 }
 
-const SummaryStats: React.FC<SummaryStatsProps> = ({ modelExecutions, serverData }) => {
+const SummaryStats: React.FC<SummaryStatsProps> = ({ modelExecutions, serverData, activeExecutions, totalModelSize }) => {
   return (
     <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8 max-w-4xl mx-auto">
       <Card className="text-center">
@@ -24,7 +26,7 @@ const SummaryStats: React.FC<SummaryStatsProps> = ({ modelExecutions, serverData
         <CardContent className="pt-6">
           <div className="text-2xl font-bold text-green-500">
             <AnimatedCounter
-              target={modelExecutions.reduce((sum, model) => sum + model.runningServers, 0)}
+              target={activeExecutions}
               duration={1500}
             />
           </div>
@@ -45,7 +47,7 @@ const SummaryStats: React.FC<SummaryStatsProps> = ({ modelExecutions, serverData
         <CardContent className="pt-6">
           <div className="text-2xl font-bold text-orange-500">
             <AnimatedCounter
-              target={Math.round(modelExecutions.reduce((sum, model) => sum + model.totalSize, 0) / (1024 * 1024 * 1024))}
+              target={totalModelSize}
               duration={1500}
             />
             <span className="text-sm font-normal">GB</span>

--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -21,9 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
-
-const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
+const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">

--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-const CommandDialog = ({ children, ...props }: DialogProps) => {
+const CommandDialog = ({ children, ...props }: { children: React.ReactNode }) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -2,10 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
-
-const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+const Textarea = React.forwardRef<HTMLTextAreaElement, React.TextareaHTMLAttributes<HTMLTextAreaElement>>(
   ({ className, ...props }, ref) => {
     return (
       <textarea

--- a/frontend/src/pages/Models.tsx
+++ b/frontend/src/pages/Models.tsx
@@ -1,0 +1,17 @@
+import Header from "@/components/Header";
+import WarningBanner from "@/components/WarningBanner";
+import ModelExecutionDashboard from "@/components/ModelExecutionDashboard";
+import Footer from "@/components/Footer";
+
+const Models = () => {
+  return (
+    <div className="min-h-screen bg-background pt-[88px]">
+      <Header />
+      <WarningBanner />
+      <ModelExecutionDashboard />
+      <Footer />
+    </div>
+  );
+};
+
+export default Models;

--- a/frontend/src/types/ModelExecution.ts
+++ b/frontend/src/types/ModelExecution.ts
@@ -22,12 +22,15 @@ export interface ServerData {
   status: string;
 }
 
-export interface ModelExecution {
+export interface ModelMetadata {
   modelName: string;
+  averageSize: number;
+}
+
+export interface ServerAggregation {
   totalServers: number;
   runningServers: number;
   totalSize: number;
-  averageSize: number;
   servers: {
     server: ServerData;
     isRunning: boolean;
@@ -35,9 +38,14 @@ export interface ModelExecution {
     modelSize: number;
     lastSeen: string;
   }[];
+}
+
+export interface ExecutionStatistics {
   lastActivity: string;
   executionFrequency: number;
 }
+
+export interface ModelExecution extends ModelMetadata, ServerAggregation, ExecutionStatistics {}
 
 export type SortOption = 'name' | 'servers' | 'running' | 'frequency' | 'size';
 export type SortDirection = 'asc' | 'desc';

--- a/frontend/src/types/ModelExecution.ts
+++ b/frontend/src/types/ModelExecution.ts
@@ -1,0 +1,44 @@
+export interface ServerModel {
+  name: string;
+  model: string;
+  size: number;
+}
+
+export interface ServerData {
+  ip: string;
+  port: number;
+  version: string;
+  city: string;
+  country: string;
+  country_name: string;
+  region: string;
+  latitude: string;
+  longitude: string;
+  local: ServerModel[];
+  running: ServerModel[];
+  first_seen_online: string;
+  last_observed: string;
+  age: string;
+  status: string;
+}
+
+export interface ModelExecution {
+  modelName: string;
+  totalServers: number;
+  runningServers: number;
+  totalSize: number;
+  averageSize: number;
+  servers: {
+    server: ServerData;
+    isRunning: boolean;
+    isLocal: boolean;
+    modelSize: number;
+    lastSeen: string;
+  }[];
+  lastActivity: string;
+  executionFrequency: number;
+}
+
+export type SortOption = 'name' | 'servers' | 'running' | 'frequency' | 'size';
+export type SortDirection = 'asc' | 'desc';
+export type StatusFilter = 'all' | 'running' | 'stopped' | 'available';

--- a/frontend/src/utils/stats-calculator.ts
+++ b/frontend/src/utils/stats-calculator.ts
@@ -1,0 +1,9 @@
+import { ModelExecution } from '@/types/ModelExecution';
+
+export const calculateActiveExecutions = (modelExecutions: ModelExecution[]): number => {
+  return modelExecutions.reduce((sum, model) => sum + model.runningServers, 0);
+};
+
+export const calculateTotalModelSize = (modelExecutions: ModelExecution[]): number => {
+  return Math.round(modelExecutions.reduce((sum, model) => sum + model.totalSize, 0) / (1024 * 1024 * 1024));
+};

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,5 +1,6 @@
-
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
+import tailwindcssTypography from "@tailwindcss/typography";
 
 export default {
 	darkMode: ["class"],
@@ -96,5 +97,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+	plugins: [tailwindcssAnimate, tailwindcssTypography],
 } satisfies Config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "project",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
the 800+ lines god component is now refactored into several components inside dashboard/ while maintaining functionality. also made updates to copy. stil need to finalize the haiku, and how to display it better. 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Refactored the large model execution dashboard component into smaller, focused components under the dashboard directory, improving code structure and maintainability. Added a new /models page with a dedicated dashboard, updated navigation, and improved UI copy.

- **Refactors**
  - Split the 800+ line dashboard into BasePage, FilterControls, ModelList, ModelCard, PaginationControls, and SummaryStats components.
  - Centralized static UI elements into BasePage for easier management.
  - Updated types and minor UI components for consistency.

- **New Features**
  - Added a /models route and navigation link.
  - Introduced a paginated, filterable, and sortable model execution dashboard with summary stats and improved user guidance.

<!-- End of auto-generated description by cubic. -->

