### PR TITLE
Refactor format size

### DIFF
--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -4,6 +4,7 @@ import { ArrowRight, Shield, AlertTriangle, Shuffle, AlertCircle, Zap, Eye, Cloc
 import Map from "./Map";
 import { formatDistanceToNowStrict } from "date-fns";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { formatSize } from "@/lib/utils";
 
 interface ServerModel {
   name: string;
@@ -101,17 +102,6 @@ const Hero = () => {
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
       console.error('Failed to copy server URL: ', err);
-    }
-  };
-
-  const formatSize = (bytes: number) => {
-    const mb = bytes / (1024 * 1024);
-    const gb = bytes / (1024 * 1024 * 1024);
-    
-    if (gb >= 1) {
-      return `${gb.toFixed(1)}GB`;
-    } else {
-      return `${mb.toFixed(0)}MB`;
     }
   };
 

--- a/frontend/src/components/LocationInfo.tsx
+++ b/frontend/src/components/LocationInfo.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { MapPin, Clock, Shuffle, AlertCircle, Zap, Eye } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import Map from "./Map";
+import { formatSize } from "@/lib/utils";
 
 interface ServerModel {
   name: string;
@@ -75,17 +76,6 @@ const LocationInfo = () => {
 
   const handleRefresh = () => {
     fetchRandomServer(true);
-  };
-
-  const formatSize = (bytes: number) => {
-    const mb = bytes / (1024 * 1024);
-    const gb = bytes / (1024 * 1024 * 1024);
-    
-    if (gb >= 1) {
-      return `${gb.toFixed(1)}GB`;
-    } else {
-      return `${mb.toFixed(0)}MB`;
-    }
   };
 
   const formatTimestamp = (dateString: string) => {

--- a/frontend/src/components/ModelExecutionDashboard.tsx
+++ b/frontend/src/components/ModelExecutionDashboard.tsx
@@ -6,6 +6,7 @@ import FilterControls from './dashboard/FilterControls';
 import ModelList from './dashboard/ModelList';
 import PaginationControls from './dashboard/PaginationControls';
 import { formatDistanceToNowStrict } from "date-fns";
+import { calculateActiveExecutions, calculateTotalModelSize } from '@/utils/stats-calculator';
 
 const ModelExecutionDashboard = () => {
   const [serverData, setServerData] = useState<ServerData[]>([]);
@@ -69,13 +70,13 @@ const ModelExecutionDashboard = () => {
         if (!modelMap.has(key)) {
           modelMap.set(key, {
             modelName: model.name,
+            averageSize: 0,
             totalServers: 0,
             runningServers: 0,
             totalSize: 0,
-            averageSize: 0,
             servers: [],
             lastActivity: server.last_observed,
-            executionFrequency: 0
+            executionFrequency: 0,
           });
         }
         
@@ -106,13 +107,13 @@ const ModelExecutionDashboard = () => {
         if (!modelMap.has(key)) {
           modelMap.set(key, {
             modelName: model.name,
+            averageSize: 0,
             totalServers: 0,
             runningServers: 0,
             totalSize: 0,
-            averageSize: 0,
             servers: [],
             lastActivity: server.last_observed,
-            executionFrequency: 0
+            executionFrequency: 0,
           });
         }
         
@@ -259,9 +260,17 @@ const ModelExecutionDashboard = () => {
     return Array.from(servers).sort();
   }, [serverData]);
 
+  const activeExecutions = useMemo(() => calculateActiveExecutions(modelExecutions), [modelExecutions]);
+  const totalModelSize = useMemo(() => calculateTotalModelSize(modelExecutions), [modelExecutions]);
+
   return (
     <BasePage loading={loading} error={error} retry={() => fetchServerData()}>
-      <SummaryStats modelExecutions={modelExecutions} serverData={serverData} />
+      <SummaryStats
+        modelExecutions={modelExecutions}
+        serverData={serverData}
+        activeExecutions={activeExecutions}
+        totalModelSize={totalModelSize}
+      />
       <FilterControls
         searchTerm={searchTerm}
         setSearchTerm={setSearchTerm}

--- a/frontend/src/components/VersionLeaderboard.tsx
+++ b/frontend/src/components/VersionLeaderboard.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Trophy, Medal, Award, Server, HardDrive, Shield } from 'lucide-react';
 import AnimatedCounter from './AnimatedCounter';
 import { Button } from "@/components/ui/button";
+import { formatSize } from '@/lib/utils';
 
 interface ServerModel {
   name: string;
@@ -45,15 +46,6 @@ const VersionLeaderboard = () => {
     // Extract major.minor from version strings like "0.5.10", "0.3.11", "0.5.7-0-ga420a45-dirty"
     const match = versionString.match(/^(\d+\.\d+)/);
     return match ? match[1] : versionString;
-  };
-
-  const formatSize = (bytes: number): string => {
-    const gb = bytes / (1024 * 1024 * 1024);
-    if (gb >= 1) {
-      return `${gb.toFixed(1)}GB`;
-    }
-    const mb = bytes / (1024 * 1024);
-    return `${mb.toFixed(0)}MB`;
   };
 
   useEffect(() => {

--- a/frontend/src/components/dashboard/BasePage.tsx
+++ b/frontend/src/components/dashboard/BasePage.tsx
@@ -12,18 +12,21 @@ const DashboardHeader = () => {
         {/* Haiku */}
         <div className="max-w-md mx-auto p-4 bg-gradient-to-r from-blue-500/10 to-purple-500/10 border border-blue-500/20 rounded-lg">
           <div className="text-sm font-mono text-muted-foreground italic leading-relaxed">
-            No keys, no limits here.
-            AI models run wild and free.
-            Internet's playground.
+            <div>No keys, no limits here</div>
+            <div>AI models run wild and free—</div>
+            <div>Internet's playground</div>
           </div>
         </div>
 
         {/* Body copy */}
         <div className="text-muted-foreground max-w-3xl mx-auto space-y-2">
-          <p className="text-sm font-mono italic leading-relaxed">
-            "Choose your AI model!"
-            Developers cry, you click
-            Who made this dashboard?
+          <p>
+            Welcome to the wild west of AI, where LLM servers roam free without authentication, rate limits, or adult supervision.
+            These beautifully exposed endpoints are running everything from creative writing assistants to code generators—all waiting for your prompts.
+          </p>
+          <p className="text-sm">
+            What makes them special? Zero barriers, infinite possibilities, and the kind of open access that would make security teams weep.
+            Perfect for experimentation, research, or just seeing what happens when AI meets the honor system.
           </p>
         </div>
       </div>

--- a/frontend/src/components/dashboard/ModelCard.tsx
+++ b/frontend/src/components/dashboard/ModelCard.tsx
@@ -12,7 +12,7 @@ import {
   HardDrive
 } from "lucide-react";
 import { formatDistanceToNowStrict } from "date-fns";
-import { ModelExecution } from '@/types/ModelExecution';
+import { ModelExecution, ModelMetadata, ServerAggregation, ExecutionStatistics } from '@/types/ModelExecution';
 
 interface ModelCardProps {
   model: ModelExecution;

--- a/frontend/src/components/dashboard/ModelCard.tsx
+++ b/frontend/src/components/dashboard/ModelCard.tsx
@@ -129,7 +129,7 @@ const ModelCard: React.FC<ModelCardProps> = ({ model, isExpanded, toggleExpansio
                 </h4>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
                   {model.servers.map((serverInfo, index) => (
-                    <Card key={`${serverInfo.server.ip}-${serverInfo.server.port}`} className="p-4">
+                    <Card key={`${serverInfo.server.ip}-${serverInfo.server.port}-${index}`} className="p-4">
                       <div className="space-y-2">
                         <div className="flex items-center justify-between">
                           <div className="font-mono text-sm">

--- a/frontend/src/components/dashboard/ModelCard.tsx
+++ b/frontend/src/components/dashboard/ModelCard.tsx
@@ -13,21 +13,13 @@ import {
 } from "lucide-react";
 import { formatDistanceToNowStrict } from "date-fns";
 import { ModelExecution, ModelMetadata, ServerAggregation, ExecutionStatistics } from '@/types/ModelExecution';
+import { formatSize } from "@/lib/utils";
 
 interface ModelCardProps {
   model: ModelExecution;
   isExpanded: boolean;
   toggleExpansion: (modelName: string) => void;
 }
-
-const formatSize = (bytes: number) => {
-  const gb = bytes / (1024 * 1024 * 1024);
-  if (gb >= 1) {
-    return `${gb.toFixed(1)}GB`;
-  }
-  const mb = bytes / (1024 * 1024);
-  return `${mb.toFixed(0)}MB`;
-};
 
 const formatTimestamp = (dateString: string) => {
   try {

--- a/frontend/src/components/dashboard/ModelCard.tsx
+++ b/frontend/src/components/dashboard/ModelCard.tsx
@@ -129,7 +129,7 @@ const ModelCard: React.FC<ModelCardProps> = ({ model, isExpanded, toggleExpansio
                 </h4>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
                   {model.servers.map((serverInfo, index) => (
-                    <Card key={`${serverInfo.server.ip}-${serverInfo.server.port}-${index}`} className="p-4">
+                    <Card key={`${serverInfo.server.ip}-${serverInfo.server.port}`} className="p-4">
                       <div className="space-y-2">
                         <div className="flex items-center justify-between">
                           <div className="font-mono text-sm">

--- a/frontend/src/components/dashboard/SummaryStats.tsx
+++ b/frontend/src/components/dashboard/SummaryStats.tsx
@@ -6,9 +6,11 @@ import { ModelExecution, ServerData } from '@/types/ModelExecution';
 interface SummaryStatsProps {
   modelExecutions: ModelExecution[];
   serverData: ServerData[];
+  activeExecutions: number;
+  totalModelSize: number;
 }
 
-const SummaryStats: React.FC<SummaryStatsProps> = ({ modelExecutions, serverData }) => {
+const SummaryStats: React.FC<SummaryStatsProps> = ({ modelExecutions, serverData, activeExecutions, totalModelSize }) => {
   return (
     <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8 max-w-4xl mx-auto">
       <Card className="text-center">
@@ -24,7 +26,7 @@ const SummaryStats: React.FC<SummaryStatsProps> = ({ modelExecutions, serverData
         <CardContent className="pt-6">
           <div className="text-2xl font-bold text-green-500">
             <AnimatedCounter
-              target={modelExecutions.reduce((sum, model) => sum + model.runningServers, 0)}
+              target={activeExecutions}
               duration={1500}
             />
           </div>
@@ -45,7 +47,7 @@ const SummaryStats: React.FC<SummaryStatsProps> = ({ modelExecutions, serverData
         <CardContent className="pt-6">
           <div className="text-2xl font-bold text-orange-500">
             <AnimatedCounter
-              target={Math.round(modelExecutions.reduce((sum, model) => sum + model.totalSize, 0) / (1024 * 1024 * 1024))}
+              target={totalModelSize}
               duration={1500}
             />
             <span className="text-sm font-normal">GB</span>

--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-const CommandDialog = ({ children, ...props }: { children: React.ReactNode }) => {
+const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">

--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-const CommandDialog = ({ children, ...props }: DialogProps) => {
+const CommandDialog = ({ children, ...props }: { children: React.ReactNode }) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,3 +4,12 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export const formatSize = (bytes: number) => {
+  const gb = bytes / (1024 * 1024 * 1024);
+  if (gb >= 1) {
+    return `${gb.toFixed(1)}GB`;
+  }
+  const mb = bytes / (1024 * 1024);
+  return `${mb.toFixed(0)}MB`;
+};

--- a/frontend/src/types/ModelExecution.ts
+++ b/frontend/src/types/ModelExecution.ts
@@ -22,12 +22,15 @@ export interface ServerData {
   status: string;
 }
 
-export interface ModelExecution {
+export interface ModelMetadata {
   modelName: string;
+  averageSize: number;
+}
+
+export interface ServerAggregation {
   totalServers: number;
   runningServers: number;
   totalSize: number;
-  averageSize: number;
   servers: {
     server: ServerData;
     isRunning: boolean;
@@ -35,9 +38,14 @@ export interface ModelExecution {
     modelSize: number;
     lastSeen: string;
   }[];
+}
+
+export interface ExecutionStatistics {
   lastActivity: string;
   executionFrequency: number;
 }
+
+export interface ModelExecution extends ModelMetadata, ServerAggregation, ExecutionStatistics {}
 
 export type SortOption = 'name' | 'servers' | 'running' | 'frequency' | 'size';
 export type SortDirection = 'asc' | 'desc';

--- a/frontend/src/utils/stats-calculator.ts
+++ b/frontend/src/utils/stats-calculator.ts
@@ -1,0 +1,9 @@
+import { ModelExecution } from '@/types/ModelExecution';
+
+export const calculateActiveExecutions = (modelExecutions: ModelExecution[]): number => {
+  return modelExecutions.reduce((sum, model) => sum + model.runningServers, 0);
+};
+
+export const calculateTotalModelSize = (modelExecutions: ModelExecution[]): number => {
+  return Math.round(modelExecutions.reduce((sum, model) => sum + model.totalSize, 0) / (1024 * 1024 * 1024));
+};

--- a/run_dev.sh
+++ b/run_dev.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd frontend
+npm run dev -- --port 3000


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Refactored the formatSize helper into a shared utility and updated all components to use it, reducing code duplication and ensuring consistent size formatting.

- **Refactors**
  - Moved formatSize to frontend/src/lib/utils.ts and replaced duplicate functions in related components.
  - Added a stats-calculator utility for summary calculations.
  - Split ModelExecution types into smaller interfaces for clarity.

<!-- End of auto-generated description by cubic. -->

