### PR TITLE
Refactor/summary stats separation of concerns

### DIFF
--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -4,6 +4,7 @@ import { ArrowRight, Shield, AlertTriangle, Shuffle, AlertCircle, Zap, Eye, Cloc
 import Map from "./Map";
 import { formatDistanceToNowStrict } from "date-fns";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { formatSize } from "@/lib/utils";
 
 interface ServerModel {
   name: string;
@@ -101,17 +102,6 @@ const Hero = () => {
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
       console.error('Failed to copy server URL: ', err);
-    }
-  };
-
-  const formatSize = (bytes: number) => {
-    const mb = bytes / (1024 * 1024);
-    const gb = bytes / (1024 * 1024 * 1024);
-    
-    if (gb >= 1) {
-      return `${gb.toFixed(1)}GB`;
-    } else {
-      return `${mb.toFixed(0)}MB`;
     }
   };
 

--- a/frontend/src/components/LocationInfo.tsx
+++ b/frontend/src/components/LocationInfo.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { MapPin, Clock, Shuffle, AlertCircle, Zap, Eye } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import Map from "./Map";
+import { formatSize } from "@/lib/utils";
 
 interface ServerModel {
   name: string;
@@ -75,17 +76,6 @@ const LocationInfo = () => {
 
   const handleRefresh = () => {
     fetchRandomServer(true);
-  };
-
-  const formatSize = (bytes: number) => {
-    const mb = bytes / (1024 * 1024);
-    const gb = bytes / (1024 * 1024 * 1024);
-    
-    if (gb >= 1) {
-      return `${gb.toFixed(1)}GB`;
-    } else {
-      return `${mb.toFixed(0)}MB`;
-    }
   };
 
   const formatTimestamp = (dateString: string) => {

--- a/frontend/src/components/ModelExecutionDashboard.tsx
+++ b/frontend/src/components/ModelExecutionDashboard.tsx
@@ -6,7 +6,6 @@ import FilterControls from './dashboard/FilterControls';
 import ModelList from './dashboard/ModelList';
 import PaginationControls from './dashboard/PaginationControls';
 import { formatDistanceToNowStrict } from "date-fns";
-import { calculateActiveExecutions, calculateTotalModelSize } from '@/utils/stats-calculator';
 
 const ModelExecutionDashboard = () => {
   const [serverData, setServerData] = useState<ServerData[]>([]);
@@ -260,16 +259,11 @@ const ModelExecutionDashboard = () => {
     return Array.from(servers).sort();
   }, [serverData]);
 
-  const activeExecutions = useMemo(() => calculateActiveExecutions(modelExecutions), [modelExecutions]);
-  const totalModelSize = useMemo(() => calculateTotalModelSize(modelExecutions), [modelExecutions]);
-
   return (
     <BasePage loading={loading} error={error} retry={() => fetchServerData()}>
       <SummaryStats
         modelExecutions={modelExecutions}
         serverData={serverData}
-        activeExecutions={activeExecutions}
-        totalModelSize={totalModelSize}
       />
       <FilterControls
         searchTerm={searchTerm}

--- a/frontend/src/components/VersionLeaderboard.tsx
+++ b/frontend/src/components/VersionLeaderboard.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Trophy, Medal, Award, Server, HardDrive, Shield } from 'lucide-react';
 import AnimatedCounter from './AnimatedCounter';
 import { Button } from "@/components/ui/button";
+import { formatSize } from '@/lib/utils';
 
 interface ServerModel {
   name: string;
@@ -45,15 +46,6 @@ const VersionLeaderboard = () => {
     // Extract major.minor from version strings like "0.5.10", "0.3.11", "0.5.7-0-ga420a45-dirty"
     const match = versionString.match(/^(\d+\.\d+)/);
     return match ? match[1] : versionString;
-  };
-
-  const formatSize = (bytes: number): string => {
-    const gb = bytes / (1024 * 1024 * 1024);
-    if (gb >= 1) {
-      return `${gb.toFixed(1)}GB`;
-    }
-    const mb = bytes / (1024 * 1024);
-    return `${mb.toFixed(0)}MB`;
   };
 
   useEffect(() => {

--- a/frontend/src/components/dashboard/ModelCard.tsx
+++ b/frontend/src/components/dashboard/ModelCard.tsx
@@ -13,21 +13,13 @@ import {
 } from "lucide-react";
 import { formatDistanceToNowStrict } from "date-fns";
 import { ModelExecution, ModelMetadata, ServerAggregation, ExecutionStatistics } from '@/types/ModelExecution';
+import { formatSize } from "@/lib/utils";
 
 interface ModelCardProps {
   model: ModelExecution;
   isExpanded: boolean;
   toggleExpansion: (modelName: string) => void;
 }
-
-const formatSize = (bytes: number) => {
-  const gb = bytes / (1024 * 1024 * 1024);
-  if (gb >= 1) {
-    return `${gb.toFixed(1)}GB`;
-  }
-  const mb = bytes / (1024 * 1024);
-  return `${mb.toFixed(0)}MB`;
-};
 
 const formatTimestamp = (dateString: string) => {
   try {

--- a/frontend/src/components/dashboard/SummaryStats.tsx
+++ b/frontend/src/components/dashboard/SummaryStats.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import AnimatedCounter from '../AnimatedCounter';
 import { ModelExecution, ServerData } from '@/types/ModelExecution';
 import { calculateActiveExecutions, calculateTotalModelSize } from '@/utils/stats-calculator';
+import { formatBytesToGB } from '@/utils/formatting';
 
 interface SummaryStatsProps {
   modelExecutions: ModelExecution[];
@@ -11,7 +12,8 @@ interface SummaryStatsProps {
 
 const SummaryStats: React.FC<SummaryStatsProps> = ({ modelExecutions, serverData }) => {
   const activeExecutions = calculateActiveExecutions(modelExecutions);
-  const totalModelSize = calculateTotalModelSize(modelExecutions);
+  const totalModelSizeBytes = calculateTotalModelSize(modelExecutions);
+  const totalModelSizeGB = formatBytesToGB(totalModelSizeBytes);
 
   return (
     <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8 max-w-4xl mx-auto">
@@ -49,7 +51,7 @@ const SummaryStats: React.FC<SummaryStatsProps> = ({ modelExecutions, serverData
         <CardContent className="pt-6">
           <div className="text-2xl font-bold text-orange-500">
             <AnimatedCounter
-              target={totalModelSize}
+              target={totalModelSizeGB}
               duration={1500}
             />
             <span className="text-sm font-normal">GB</span>

--- a/frontend/src/components/dashboard/SummaryStats.tsx
+++ b/frontend/src/components/dashboard/SummaryStats.tsx
@@ -2,15 +2,17 @@ import React from 'react';
 import { Card, CardContent } from "@/components/ui/card";
 import AnimatedCounter from '../AnimatedCounter';
 import { ModelExecution, ServerData } from '@/types/ModelExecution';
+import { calculateActiveExecutions, calculateTotalModelSize } from '@/utils/stats-calculator';
 
 interface SummaryStatsProps {
   modelExecutions: ModelExecution[];
   serverData: ServerData[];
-  activeExecutions: number;
-  totalModelSize: number;
 }
 
-const SummaryStats: React.FC<SummaryStatsProps> = ({ modelExecutions, serverData, activeExecutions, totalModelSize }) => {
+const SummaryStats: React.FC<SummaryStatsProps> = ({ modelExecutions, serverData }) => {
+  const activeExecutions = calculateActiveExecutions(modelExecutions);
+  const totalModelSize = calculateTotalModelSize(modelExecutions);
+
   return (
     <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8 max-w-4xl mx-auto">
       <Card className="text-center">

--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-const CommandDialog = ({ children, ...props }: { children: React.ReactNode }) => {
+const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,3 +4,12 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export const formatSize = (bytes: number) => {
+  const gb = bytes / (1024 * 1024 * 1024);
+  if (gb >= 1) {
+    return `${gb.toFixed(1)}GB`;
+  }
+  const mb = bytes / (1024 * 1024);
+  return `${mb.toFixed(0)}MB`;
+};

--- a/frontend/src/utils/formatting.ts
+++ b/frontend/src/utils/formatting.ts
@@ -1,0 +1,3 @@
+export const formatBytesToGB = (bytes: number): number => {
+  return Math.round(bytes / (1024 * 1024 * 1024));
+};

--- a/frontend/src/utils/stats-calculator.ts
+++ b/frontend/src/utils/stats-calculator.ts
@@ -5,5 +5,5 @@ export const calculateActiveExecutions = (modelExecutions: ModelExecution[]): nu
 };
 
 export const calculateTotalModelSize = (modelExecutions: ModelExecution[]): number => {
-  return Math.round(modelExecutions.reduce((sum, model) => sum + model.totalSize, 0) / (1024 * 1024 * 1024));
+  return modelExecutions.reduce((sum, model) => sum + model.totalSize, 0);
 };

--- a/run_dev.sh
+++ b/run_dev.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd frontend
+npm run dev -- --port 3000


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Moved the formatSize helper to a shared utility and updated all components to use it. Refactored SummaryStats to calculate its own statistics instead of relying on parent components.

- **Refactors**
  - Removed duplicate formatSize functions from multiple components.
  - SummaryStats now computes activeExecutions and totalModelSize internally.
  - Minor type fix in CommandDialog props.
  - Added a run_dev.sh script for easier local development.

<!-- End of auto-generated description by cubic. -->

