### PR TITLE
Decouple format size util

### DIFF
--- a/frontend/src/components/VersionLeaderboard.tsx
+++ b/frontend/src/components/VersionLeaderboard.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { Trophy, Medal, Award, Server, HardDrive, Shield } from 'lucide-react';
 import AnimatedCounter from './AnimatedCounter';
+import { useFormatSize } from '@/hooks/useFormatSize';
 import { Button } from "@/components/ui/button";
-import { formatSize } from '@/lib/utils';
 
 interface ServerModel {
   name: string;
@@ -41,6 +41,7 @@ const VersionLeaderboard = () => {
   const [versionGroups, setVersionGroups] = useState<VersionGroup[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const formatSize = useFormatSize();
 
   const parseVersion = (versionString: string): string => {
     // Extract major.minor from version strings like "0.5.10", "0.3.11", "0.5.7-0-ga420a45-dirty"

--- a/frontend/src/hooks/useFormatSize.ts
+++ b/frontend/src/hooks/useFormatSize.ts
@@ -1,0 +1,14 @@
+import { useCallback } from 'react';
+
+export const useFormatSize = () => {
+  const formatSize = useCallback((bytes: number) => {
+    const gb = bytes / (1024 * 1024 * 1024);
+    if (gb >= 1) {
+      return `${gb.toFixed(1)}GB`;
+    }
+    const mb = bytes / (1024 * 1024);
+    return `${mb.toFixed(0)}MB`;
+  }, []);
+
+  return formatSize;
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -5,11 +5,3 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-export const formatSize = (bytes: number) => {
-  const gb = bytes / (1024 * 1024 * 1024);
-  if (gb >= 1) {
-    return `${gb.toFixed(1)}GB`;
-  }
-  const mb = bytes / (1024 * 1024);
-  return `${mb.toFixed(0)}MB`;
-};


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Moved the formatSize logic from a shared utility to a new useFormatSize hook and updated VersionLeaderboard to use the hook.

- **Refactors**
  - Removed formatSize from utils and encapsulated it in a custom hook for better separation of concerns.

<!-- End of auto-generated description by cubic. -->

