### PR TITLE
Refactor/move formatsize

### DIFF
--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -4,7 +4,7 @@ import { ArrowRight, Shield, AlertTriangle, Shuffle, AlertCircle, Zap, Eye, Cloc
 import Map from "./Map";
 import { formatDistanceToNowStrict } from "date-fns";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
-import { formatSize } from "@/lib/utils";
+import { formatSize } from "@/utils/formatting";
 
 interface ServerModel {
   name: string;

--- a/frontend/src/components/LocationInfo.tsx
+++ b/frontend/src/components/LocationInfo.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { MapPin, Clock, Shuffle, AlertCircle, Zap, Eye } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import Map from "./Map";
-import { formatSize } from "@/lib/utils";
+import { formatSize } from "@/utils/formatting";
 
 interface ServerModel {
   name: string;

--- a/frontend/src/components/ModelExecutionDashboard.tsx
+++ b/frontend/src/components/ModelExecutionDashboard.tsx
@@ -6,7 +6,6 @@ import FilterControls from './dashboard/FilterControls';
 import ModelList from './dashboard/ModelList';
 import PaginationControls from './dashboard/PaginationControls';
 import { formatDistanceToNowStrict } from "date-fns";
-import { calculateActiveExecutions, calculateTotalModelSize } from '@/utils/stats-calculator';
 
 const ModelExecutionDashboard = () => {
   const [serverData, setServerData] = useState<ServerData[]>([]);
@@ -260,16 +259,11 @@ const ModelExecutionDashboard = () => {
     return Array.from(servers).sort();
   }, [serverData]);
 
-  const activeExecutions = useMemo(() => calculateActiveExecutions(modelExecutions), [modelExecutions]);
-  const totalModelSize = useMemo(() => calculateTotalModelSize(modelExecutions), [modelExecutions]);
-
   return (
     <BasePage loading={loading} error={error} retry={() => fetchServerData()}>
       <SummaryStats
         modelExecutions={modelExecutions}
         serverData={serverData}
-        activeExecutions={activeExecutions}
-        totalModelSize={totalModelSize}
       />
       <FilterControls
         searchTerm={searchTerm}

--- a/frontend/src/components/VersionLeaderboard.tsx
+++ b/frontend/src/components/VersionLeaderboard.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Trophy, Medal, Award, Server, HardDrive, Shield } from 'lucide-react';
 import AnimatedCounter from './AnimatedCounter';
 import { Button } from "@/components/ui/button";
-import { formatSize } from '@/lib/utils';
+import { formatSize } from '@/utils/formatting';
 
 interface ServerModel {
   name: string;

--- a/frontend/src/components/dashboard/ModelCard.tsx
+++ b/frontend/src/components/dashboard/ModelCard.tsx
@@ -13,7 +13,7 @@ import {
 } from "lucide-react";
 import { formatDistanceToNowStrict } from "date-fns";
 import { ModelExecution, ModelMetadata, ServerAggregation, ExecutionStatistics } from '@/types/ModelExecution';
-import { formatSize } from "@/lib/utils";
+import { formatSize } from "@/utils/formatting";
 
 interface ModelCardProps {
   model: ModelExecution;

--- a/frontend/src/components/dashboard/SummaryStats.tsx
+++ b/frontend/src/components/dashboard/SummaryStats.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import AnimatedCounter from '../AnimatedCounter';
 import { ModelExecution, ServerData } from '@/types/ModelExecution';
 import { calculateActiveExecutions, calculateTotalModelSize } from '@/utils/stats-calculator';
+import { formatBytesToGB } from '@/utils/formatting';
 
 interface SummaryStatsProps {
   modelExecutions: ModelExecution[];
@@ -11,7 +12,8 @@ interface SummaryStatsProps {
 
 const SummaryStats: React.FC<SummaryStatsProps> = ({ modelExecutions, serverData }) => {
   const activeExecutions = calculateActiveExecutions(modelExecutions);
-  const totalModelSize = calculateTotalModelSize(modelExecutions);
+  const totalModelSizeBytes = calculateTotalModelSize(modelExecutions);
+  const totalModelSizeGB = formatBytesToGB(totalModelSizeBytes);
 
   return (
     <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8 max-w-4xl mx-auto">
@@ -49,7 +51,7 @@ const SummaryStats: React.FC<SummaryStatsProps> = ({ modelExecutions, serverData
         <CardContent className="pt-6">
           <div className="text-2xl font-bold text-orange-500">
             <AnimatedCounter
-              target={totalModelSize}
+              target={totalModelSizeGB}
               duration={1500}
             />
             <span className="text-sm font-normal">GB</span>

--- a/frontend/src/components/dashboard/SummaryStats.tsx
+++ b/frontend/src/components/dashboard/SummaryStats.tsx
@@ -2,15 +2,17 @@ import React from 'react';
 import { Card, CardContent } from "@/components/ui/card";
 import AnimatedCounter from '../AnimatedCounter';
 import { ModelExecution, ServerData } from '@/types/ModelExecution';
+import { calculateActiveExecutions, calculateTotalModelSize } from '@/utils/stats-calculator';
 
 interface SummaryStatsProps {
   modelExecutions: ModelExecution[];
   serverData: ServerData[];
-  activeExecutions: number;
-  totalModelSize: number;
 }
 
-const SummaryStats: React.FC<SummaryStatsProps> = ({ modelExecutions, serverData, activeExecutions, totalModelSize }) => {
+const SummaryStats: React.FC<SummaryStatsProps> = ({ modelExecutions, serverData }) => {
+  const activeExecutions = calculateActiveExecutions(modelExecutions);
+  const totalModelSize = calculateTotalModelSize(modelExecutions);
+
   return (
     <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8 max-w-4xl mx-auto">
       <Card className="text-center">

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -5,11 +5,3 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-export const formatSize = (bytes: number) => {
-  const gb = bytes / (1024 * 1024 * 1024);
-  if (gb >= 1) {
-    return `${gb.toFixed(1)}GB`;
-  }
-  const mb = bytes / (1024 * 1024);
-  return `${mb.toFixed(0)}MB`;
-};

--- a/frontend/src/utils/formatting.ts
+++ b/frontend/src/utils/formatting.ts
@@ -1,3 +1,12 @@
 export const formatBytesToGB = (bytes: number): number => {
   return Math.round(bytes / (1024 * 1024 * 1024));
 };
+
+export const formatSize = (bytes: number) => {
+  const gb = bytes / (1024 * 1024 * 1024);
+  if (gb >= 1) {
+    return `${gb.toFixed(1)}GB`;
+  }
+  const mb = bytes / (1024 * 1024);
+  return `${mb.toFixed(0)}MB`;
+};

--- a/frontend/src/utils/formatting.ts
+++ b/frontend/src/utils/formatting.ts
@@ -1,0 +1,3 @@
+export const formatBytesToGB = (bytes: number): number => {
+  return Math.round(bytes / (1024 * 1024 * 1024));
+};

--- a/frontend/src/utils/stats-calculator.ts
+++ b/frontend/src/utils/stats-calculator.ts
@@ -5,5 +5,5 @@ export const calculateActiveExecutions = (modelExecutions: ModelExecution[]): nu
 };
 
 export const calculateTotalModelSize = (modelExecutions: ModelExecution[]): number => {
-  return Math.round(modelExecutions.reduce((sum, model) => sum + model.totalSize, 0) / (1024 * 1024 * 1024));
+  return modelExecutions.reduce((sum, model) => sum + model.totalSize, 0);
 };


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Moved the formatSize function to a new formatting utility and updated all imports. Refactored SummaryStats to handle its own statistics calculation and improved separation of formatting and calculation logic.

- **Refactors**
  - Created frontend/src/utils/formatting.ts for size formatting functions.
  - Updated SummaryStats to compute active executions and total model size internally.

<!-- End of auto-generated description by cubic. -->

