### PR TITLE
fix: Correct total model size calculation

### DIFF
--- a/frontend/src/utils/stats-calculator.ts
+++ b/frontend/src/utils/stats-calculator.ts
@@ -6,6 +6,6 @@ export const calculateActiveExecutions = (modelExecutions: ModelExecution[]): nu
 };
 
 export const calculateTotalModelSize = (modelExecutions: ModelExecution[]): number => {
-  const totalSizeInBytes = modelExecutions.reduce((sum, model) => sum + model.aggregation.totalSize, 0);
-  return Math.round(convertBytesToGB(totalSizeInBytes));
+  const totalSizeInBytes = modelExecutions.reduce((sum, model) => sum + model.metadata.averageSize, 0);
+  return totalSizeInBytes;
 };


### PR DESCRIPTION
The total model size stat on the /models page was showing 0 because it was summing the total size of each model across all servers, which was incorrect. This change corrects the calculation to sum the average size of each unique model.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the total model size calculation on the /models page to sum the average size of each unique model instead of the total size across all servers.

<!-- End of auto-generated description by cubic. -->

