### PR TITLE
Refactor theme handling to use a centralized provider

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import Pricing from "./pages/Pricing";
 import About from "./pages/About";
 import Privacy from "./pages/Privacy";
 import Legal from "./pages/Legal";
+import { ThemeProvider } from "./providers/theme-provider";
 
 // Create Sentry-wrapped Router component for automatic route tracking
 const SentryBrowserRouter = Sentry.withSentryRouting(BrowserRouter);
@@ -53,7 +54,7 @@ const ErrorFallback = ({ error, resetError }) => (
 const App = () => (
   <Sentry.ErrorBoundary fallback={<ErrorFallback />} showDialog>
     <QueryClientProvider client={queryClient}>
-      {/* <TooltipProvider> */}
+      <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
         <SentryBrowserRouter>
           <Routes>
             <Route path="/" element={<Index />} />
@@ -67,7 +68,7 @@ const App = () => (
             <Route path="*" element={<NotFound />} />
           </Routes>
         </SentryBrowserRouter>
-      {/* </TooltipProvider> */}
+      </ThemeProvider>
     </QueryClientProvider>
   </Sentry.ErrorBoundary>
 );

--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import mapboxgl from 'mapbox-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
+import { useTheme } from '@/providers/theme-provider';
 import { MapPin, Loader2, AlertCircle } from "lucide-react";
 
 interface MapProps {
@@ -15,38 +16,9 @@ const Map = ({ latitude, longitude, city, country }: MapProps) => {
   const map = useRef<mapboxgl.Map | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string>('');
-  const [isDarkMode, setIsDarkMode] = useState<boolean>(false);
+  const { theme } = useTheme();
+  const isDarkMode = theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
   const [currentMapStyle, setCurrentMapStyle] = useState<string>('');
-
-  // Theme detection logic that matches ThemeToggle component
-  const detectTheme = () => {
-    const theme = localStorage.getItem("theme");
-    const systemPrefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    return theme === "dark" || (!theme && systemPrefersDark);
-  };
-
-  // Initialize theme on component mount
-  useEffect(() => {
-    setIsDarkMode(detectTheme());
-  }, []);
-
-  // Listen for theme changes (storage events and manual updates)
-  useEffect(() => {
-    const handleThemeChange = () => {
-      setIsDarkMode(detectTheme());
-    };
-
-    // Listen for localStorage changes from other tabs/windows
-    window.addEventListener('storage', handleThemeChange);
-    
-    // Listen for manual theme changes (custom event)
-    window.addEventListener('themeChange', handleThemeChange);
-
-    return () => {
-      window.removeEventListener('storage', handleThemeChange);
-      window.removeEventListener('themeChange', handleThemeChange);
-    };
-  }, []);
 
   const waitForContainer = (): Promise<void> => {
     return new Promise((resolve, reject) => {

--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -17,7 +17,7 @@ const Map = ({ latitude, longitude, city, country }: MapProps) => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string>('');
   const { theme } = useTheme();
-  const isDarkMode = theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  const isDarkMode = theme === 'dark' || (theme === 'system' && typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches);
   const [currentMapStyle, setCurrentMapStyle] = useState<string>('');
 
   const waitForContainer = (): Promise<void> => {

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,37 +1,16 @@
 
 import { Moon, Sun } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { useEffect, useState } from "react";
+import { useTheme } from "@/providers/theme-provider";
 
 const ThemeToggle = () => {
-  const [isDark, setIsDark] = useState(false);
+  const { theme, setTheme } = useTheme();
 
-  useEffect(() => {
-    const theme = localStorage.getItem("theme");
-    const systemPrefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    
-    if (theme === "dark" || (!theme && systemPrefersDark)) {
-      setIsDark(true);
-      document.documentElement.classList.add("dark");
-    }
-  }, []);
+  const isDark = theme === "dark" || (theme === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches);
 
   const toggleTheme = () => {
-    const newTheme = !isDark;
-    setIsDark(newTheme);
-    
-    if (newTheme) {
-      document.documentElement.classList.add("dark");
-      localStorage.setItem("theme", "dark");
-    } else {
-      document.documentElement.classList.remove("dark");
-      localStorage.setItem("theme", "light");
-    }
-
-    // Dispatch custom event to notify other components (like Map) of theme change
-    window.dispatchEvent(new CustomEvent('themeChange', {
-      detail: { isDark: newTheme, theme: newTheme ? 'dark' : 'light' }
-    }));
+    const newTheme = isDark ? "light" : "dark";
+    setTheme(newTheme);
   };
 
   return (

--- a/frontend/src/providers/theme-provider.tsx
+++ b/frontend/src/providers/theme-provider.tsx
@@ -1,0 +1,73 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+type Theme = "dark" | "light" | "system";
+
+type ThemeProviderProps = {
+  children: React.ReactNode;
+  defaultTheme?: Theme;
+  storageKey?: string;
+};
+
+type ThemeProviderState = {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+};
+
+const initialState: ThemeProviderState = {
+  theme: "system",
+  setTheme: () => null,
+};
+
+const ThemeProviderContext = createContext<ThemeProviderState>(initialState);
+
+export function ThemeProvider({
+  children,
+  defaultTheme = "system",
+  storageKey = "vite-ui-theme",
+  ...props
+}: ThemeProviderProps) {
+  const [theme, setTheme] = useState<Theme>(
+    () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
+  );
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+
+    root.classList.remove("light", "dark");
+
+    if (theme === "system") {
+      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
+        .matches
+        ? "dark"
+        : "light";
+
+      root.classList.add(systemTheme);
+      return;
+    }
+
+    root.classList.add(theme);
+  }, [theme]);
+
+  const value = {
+    theme,
+    setTheme: (theme: Theme) => {
+      localStorage.setItem(storageKey, theme);
+      setTheme(theme);
+    },
+  };
+
+  return (
+    <ThemeProviderContext.Provider {...props} value={value}>
+      {children}
+    </ThemeProviderContext.Provider>
+  );
+}
+
+export const useTheme = () => {
+  const context = useContext(ThemeProviderContext);
+
+  if (context === undefined)
+    throw new Error("useTheme must be used within a ThemeProvider");
+
+  return context;
+};


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Refactored theme handling to use a centralized ThemeProvider, simplifying theme management across the app.

- **Refactors**
  - Replaced local theme logic in components with a shared ThemeProvider and useTheme hook.
  - Removed duplicate theme detection and event code from Map and ThemeToggle.

<!-- End of auto-generated description by cubic. -->

